### PR TITLE
Fix response filepath when contains directory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: plotly
 Type: Package
 Title: Interactive, publication-quality graphs online.
-Version: 0.5.17
+Version: 0.5.18
 Authors@R: c(person("Chris", "Parmer", role = c("aut", "cre"),
     email = "chris@plot.ly"),
     person("Scott", "Chamberlain", role = "aut",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+0.5.18 -- 22 January 2015.
+
+Return proper filepath when filename contains directories.
+
 0.5.17 -- 30 December 2014.
 
 Support date-time binning in histograms.

--- a/R/plotly-package.r
+++ b/R/plotly-package.r
@@ -7,7 +7,7 @@
 #' \itemize{
 #'  \item Package: plotly
 #'  \item Type: Package
-#'  \item Version: 0.5.17
+#'  \item Version: 0.5.18
 #'  \item Date: 2014-03-07
 #'  \item License: MIT
 #' }

--- a/R/plotly.R
+++ b/R/plotly.R
@@ -82,7 +82,7 @@ For more help, see https://plot.ly/R or contact <chris@plot.ly>.")
   
   # public attributes/methods that the user has access to
   pub <- list(username=username, key=key, filename="from api", fileopt=NULL,
-              version="0.5.17")
+              version="0.5.18")
   priv <- list()
   
   pub$makecall <- function(args, kwargs, origin) {

--- a/R/plotly.R
+++ b/R/plotly.R
@@ -105,8 +105,8 @@ For more help, see https://plot.ly/R or contact <chris@plot.ly>.")
     }
     
     resp <- fromJSON(respst, simplify = FALSE)
-    if (!is.null(resp$filename))
-      pub$filename <- resp$filename
+    if (!is.null(kwargs$filename))
+      resp$filename <- kwargs$filename
     if (!is.null(resp$error))
       cat(resp$err)
     if (!is.null(resp$warning))

--- a/tests/testthat/test-plotly-filename.R
+++ b/tests/testthat/test-plotly-filename.R
@@ -1,6 +1,6 @@
 context("Filename")
 
-test_that("Filepath with directories is returned as passed", {
+test_that("filepath with directories is returned as passed", {
   x <- c(-1.50548425849621, 0.023267831354017, -1.38460390550496,
          -0.805552814226363, 1.59651736643461, 0.936302685370894,
          0.512729504994891, -0.24492573745161, -0.465348603632604,
@@ -8,8 +8,7 @@ test_that("Filepath with directories is returned as passed", {
          -0.132866228059449, -0.336255877656944, 0.916535489109209,
          -0.936870130264329, 0.363137478307925, -1.26433467241078,
          -0.388804188531171, 0.785842426281935)
-  data = list(x=x,
-              type="histogramx")
+  data = list(x=x, type="histogramx")
   l <- list(autosize=FALSE, width=600, height=400, showlegend=FALSE)
   
   py <- plotly("get_test_user_2", "0f9es4r6tm")

--- a/tests/testthat/test-plotly-filename.R
+++ b/tests/testthat/test-plotly-filename.R
@@ -1,0 +1,21 @@
+context("Filename")
+
+test_that("Filepath with directories is returned as passed", {
+  x <- c(-1.50548425849621, 0.023267831354017, -1.38460390550496,
+         -0.805552814226363, 1.59651736643461, 0.936302685370894,
+         0.512729504994891, -0.24492573745161, -0.465348603632604,
+         0.173523456651353, 0.389491211182137, -0.275308705542518,
+         -0.132866228059449, -0.336255877656944, 0.916535489109209,
+         -0.936870130264329, 0.363137478307925, -1.26433467241078,
+         -0.388804188531171, 0.785842426281935)
+  data = list(x=x,
+              type="histogramx")
+  l <- list(autosize=FALSE, width=600, height=400, showlegend=FALSE)
+  
+  py <- plotly("get_test_user_2", "0f9es4r6tm")
+  response <- py$plotly(data, kwargs=list(layout=l, filename="directory/hist",
+                                          fileopt="overwrite"))
+  
+  expect_identical(response$filename, "directory/hist")
+  
+})


### PR DESCRIPTION
This PR addresses issue #26.

What's posted is actually fine (resulting tree in plotly account is what you expect online).

Value `kwargs$filename` is preserved under `toJSON()` but then under `postForm()` some parsing issue generates the double directory prepending...  Which in turns propagates to `fromJSON()` -- I'm talking about https://github.com/ropensci/plotly/blob/master/R/plotly.R#L107

That's why I suggest overwriting `resp$filename` with the initial `kwargs$filename` so the returned response is what you expect -- no impact on what's actually sent to plotly (as the web platform).

Note that the resulting plotly plot is private by default -- is this what we expect?

/cc @sckott @chriddyp 