### PR TITLE
Carson ribbon

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: plotly
 Type: Package
 Title: Interactive, publication-quality graphs online.
-Version: 0.5.26
+Version: 0.5.27
 Authors@R: c(person("Chris", "Parmer", role = c("aut", "cre"),
     email = "chris@plot.ly"),
     person("Scott", "Chamberlain", role = "aut",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+0.5.27 -- 19 Mar 2015
+
+Reimplement geom_ribbon as a basic polygon. Fix #191. Fix #192.
+
 0.5.26 -- 18 Mar 2015
 
 Implemented geom_rect #178

--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -760,13 +760,28 @@ gg2list <- function(p){
     merged.traces[[length(merged.traces)+1]] <- tr
   }
   
+  # -------------------------------
   # avoid redundant legends entries
-  fills <- lapply(merged.traces, function(x) paste0(x$name, "-", x$fillcolor))
-  linez <- lapply(merged.traces, function(x) paste0(x$name, "-", x$line$color))
-  marks <- lapply(merged.traces, function(x) paste0(x$name, "-",x$marker$color))
-  fill_set <- unlist(fills)
-  line_set <- unlist(linez)
-  mark_set <- unlist(marks)
+  # -------------------------------
+  # remove alpha from a color entry
+  rm_alpha <- function(x) {
+    if (length(x) == 0) return(x)
+    pat <- "^rgba\\("
+    if (!grepl(pat, x)) return(x)
+    sub(",\\s*[0]?[.]?[0-9]+\\)$", ")", sub(pat, "rgb(", x))
+  }
+  # convenient for extracting name/value of legend entries (ignoring alpha)
+  entries <- function(x, y) {
+    z <- try(x[[y]], silent = TRUE)
+    if (inherits(e, "try-error")) {
+      paste0(x$name, "-")
+    } else {
+      paste0(x$name, "-", rm_alpha(z))
+    }
+  }
+  fill_set <- unlist(lapply(merged.traces, entries, "fillcolor"))
+  line_set <- unlist(lapply(merged.traces, entries, c("line", "color")))
+  mark_set <- unlist(lapply(merged.traces, entries, c("marker", "color")))
   legend_intersect <- function(x, y) {
     i <- intersect(x, y)
     # restrict intersection to valid legend entries

--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -599,29 +599,6 @@ gg2list <- function(p){
     }
   }
   
-  # avoid redundant legends
-  fills <- lapply(trace.list, function(x) paste0(x$name, "-", x$fillcolor))
-  linez <- lapply(trace.list, function(x) paste0(x$name, "-", x$line$color))
-  marks <- lapply(trace.list, function(x) paste0(x$name, "-", x$marker$color))
-  fill_set <- unlist(fills)
-  line_set <- unlist(linez)
-  mark_set <- unlist(marks)
-  legend_intersect <- function(x, y) {
-    i <- intersect(x, y)
-    # restrict intersection to valid legend entries
-    i[grepl("-rgb[a]?\\(", i)]
-  }
-  # if there is a mark & line legend, get rid of line
-  t1 <- line_set %in% legend_intersect(mark_set, line_set)
-  # if there is a mark & fill legend, get rid of fill
-  t2 <- fill_set %in% legend_intersect(mark_set, fill_set)
-  # if there is a line & fill legend, get rid of fill
-  t3 <- fill_set %in% legend_intersect(line_set, fill_set)
-  t <- t1 | t2 | t3
-  for (m in seq_along(trace.list)) 
-    if (trace.list[[m]]$showlegend && t[m]) 
-      trace.list[[m]]$showlegend <- FALSE
-  
   # Only show a legend title if there is at least 1 trace with
   # showlegend=TRUE.
   trace.showlegend <- sapply(trace.list, "[[", "showlegend")
@@ -651,8 +628,6 @@ gg2list <- function(p){
                                 textangle=0)
     layout$annotations <- annotations
   }
-  
-  
   
   # Family font for text
   if (!is.null(theme.pars$text$family)) {
@@ -784,6 +759,31 @@ gg2list <- function(p){
     }
     merged.traces[[length(merged.traces)+1]] <- tr
   }
+  
+  # avoid redundant legends entries
+  fills <- lapply(merged.traces, function(x) paste0(x$name, "-", x$fillcolor))
+  linez <- lapply(merged.traces, function(x) paste0(x$name, "-", x$line$color))
+  marks <- lapply(merged.traces, function(x) paste0(x$name, "-",x$marker$color))
+  fill_set <- unlist(fills)
+  line_set <- unlist(linez)
+  mark_set <- unlist(marks)
+  legend_intersect <- function(x, y) {
+    i <- intersect(x, y)
+    # restrict intersection to valid legend entries
+    i[grepl("-rgb[a]?\\(", i)]
+  }
+  # if there is a mark & line legend, get rid of line
+  t1 <- line_set %in% legend_intersect(mark_set, line_set)
+  # that is, unless the mode is 'lines+markers'...
+  t1 <- t1 & !(unlist(lapply(merged.traces, "[[", "mode")) %in% "lines+markers")
+  # if there is a mark & fill legend, get rid of fill
+  t2 <- fill_set %in% legend_intersect(mark_set, fill_set)
+  # if there is a line & fill legend, get rid of fill
+  t3 <- fill_set %in% legend_intersect(line_set, fill_set)
+  t <- t1 | t2 | t3
+  for (m in seq_along(merged.traces)) 
+    if (isTRUE(merged.traces[[m]]$showlegend && t[m]))
+      merged.traces[[m]]$showlegend <- FALSE
   
   # Put the traces in correct order, according to any manually
   # specified scales. This seems to be repetitive with the trace$rank

--- a/R/trace_generation.R
+++ b/R/trace_generation.R
@@ -412,7 +412,8 @@ toBasic <- list(
     g
   },
   smoothLine=function(g) {
-    if (length(unique(g$data$group)) == 1) g$params$colour <- "#3366FF"
+    if (length(grep("^colour$", names(g$data))) == 0) 
+      g$params$colour <- "#3366FF"
     group2NA(g, "path")
   },
   smoothRibbon=function(g) {

--- a/tests/testthat/test-ggplot-ribbon.R
+++ b/tests/testthat/test-ggplot-ribbon.R
@@ -32,20 +32,22 @@ test_that("geom_ribbon() creates 1 trace & respects alpha transparency", {
 p2 <- ggplot(data = huron, aes(group = factor(decade))) + 
   geom_ribbon(aes(x = diff, ymin = level-0.1, ymax = level+0.1))
 
-test_that("geom_ribbon() group aesthetic", {
+test_that("geom_ribbon() with group aesthetic produces 1 trace", {
   info <- expect_traces(p2, 1, "group")
 })
 
 p3 <- ggplot(data = huron, aes(colour = factor(decade))) + 
   geom_ribbon(aes(x = diff, ymin = level-0.1, ymax = level+0.1))
 
-test_that("geom_ribbon() colour aesthetic", {
-  info <- expect_traces(p3, 1, "colour")
+test_that("geom_ribbon() with colour aesthetic produces multiple traces", {
+  # 10 traces -- one for each decade
+  info <- expect_traces(p3, 10, "colour")
 })
 
 p4 <- ggplot(data = huron, aes(fill = factor(decade))) + 
   geom_ribbon(aes(x = diff, ymin = level-0.1, ymax = level+0.1))
 
-test_that("geom_ribbon() fill aesthetic", {
-  info <- expect_traces(p4, 1, "fill")
+test_that("geom_ribbon() with fill aesthetic produces multiple traces", {
+  # 10 traces -- one for each decade
+  info <- expect_traces(p4, 10, "fill")
 })

--- a/tests/testthat/test-ggplot-ribbon.R
+++ b/tests/testthat/test-ggplot-ribbon.R
@@ -1,26 +1,51 @@
 context("ribbon")
 
-huron <- data.frame(year=1875:1972, level=as.vector(LakeHuron))
+expect_traces <- function(gg, n.traces, name){
+  stopifnot(is.ggplot(gg))
+  stopifnot(is.numeric(n.traces))
+  save_outputs(gg, paste0("ribbon-", name))
+  L <- gg2list(gg)
+  is.trace <- names(L) == ""
+  all.traces <- L[is.trace]
+  no.data <- sapply(all.traces, function(tr) {
+    is.null(tr[["x"]]) && is.null(tr[["y"]])
+  })
+  has.data <- all.traces[!no.data]
+  expect_equal(length(has.data), n.traces)
+  list(traces=has.data, kwargs=L$kwargs)
+}
 
-rb <- ggplot(huron, aes(x=year)) + geom_ribbon(aes(ymin=level-1, ymax=level+1))
-L <- gg2list(rb)
+huron <- data.frame(year = 1875:1972, level = as.vector(LakeHuron))
+huron$decade <- with(huron, round(year/10) * 10)
+huron$diff <- huron$year - huron$decade
 
-test_that("sanity check for geom_ribbon", {
-  expect_equal(length(L), 2)
-  expect_identical(L[[1]]$type, "scatter")
-  expect_equal(L[[1]]$x, c(huron$year[1], huron$year, rev(huron$year)))
-  expect_equal(L[[1]]$y, c(huron$level[1]-1, huron$level+1, rev(huron$level-1)))
-  expect_identical(L[[1]]$line$color, "transparent")
-})
+p1 <- ggplot(data = huron) + 
+  geom_ribbon(aes(x = year, ymin = level-1, ymax = level+1), 
+              alpha = 0.1)
 
-save_outputs(rb, "ribbon")
-
-rb2 <- ggplot(huron, aes(x=year)) + 
-  geom_ribbon(aes(ymin=level-1, ymax=level+1), alpha = 0.1)
-L2 <- gg2list(rb2)
-
-test_that("geom_ribbon respects alpha transparency", {
+test_that("geom_ribbon() creates 1 trace & respects alpha transparency", {
+  info <- expect_traces(p1, 1, "alpha")
+  tr <- info$traces[[1]]
   expect_match(L2[[1]]$fillcolor, "0.1)", fixed=TRUE)
 })
 
-save_outputs(rb2, "ribbon-alpha")
+p2 <- ggplot(data = huron, aes(group = factor(decade))) + 
+  geom_ribbon(aes(x = diff, ymin = level-0.1, ymax = level+0.1))
+
+test_that("geom_ribbon() group aesthetic", {
+  info <- expect_traces(p2, 1, "group")
+})
+
+p3 <- ggplot(data = huron, aes(colour = factor(decade))) + 
+  geom_ribbon(aes(x = diff, ymin = level-0.1, ymax = level+0.1))
+
+test_that("geom_ribbon() colour aesthetic", {
+  info <- expect_traces(p3, 1, "colour")
+})
+
+p4 <- ggplot(data = huron, aes(fill = factor(decade))) + 
+  geom_ribbon(aes(x = diff, ymin = level-0.1, ymax = level+0.1))
+
+test_that("geom_ribbon() fill aesthetic", {
+  info <- expect_traces(p4, 1, "fill")
+})

--- a/tests/testthat/test-ggplot-ribbon.R
+++ b/tests/testthat/test-ggplot-ribbon.R
@@ -26,7 +26,7 @@ p1 <- ggplot(data = huron) +
 test_that("geom_ribbon() creates 1 trace & respects alpha transparency", {
   info <- expect_traces(p1, 1, "alpha")
   tr <- info$traces[[1]]
-  expect_match(L2[[1]]$fillcolor, "0.1)", fixed=TRUE)
+  expect_match(tr$fillcolor, "0.1)", fixed=TRUE)
 })
 
 p2 <- ggplot(data = huron, aes(group = factor(decade))) + 

--- a/tests/testthat/test-ggplot-smooth.R
+++ b/tests/testthat/test-ggplot-smooth.R
@@ -62,6 +62,6 @@ p8 <- qplot(carat, price, data = d) + facet_wrap(~cut) +
 
 test_that("geom_smooth() works with facets", {
   # 3 traces for each panel
-  info <- expect_traces(p8, 15, "fill2")
+  info <- expect_traces(p8, 15, "facet")
 })
 

--- a/tests/testthat/test-ggplot-smooth.R
+++ b/tests/testthat/test-ggplot-smooth.R
@@ -32,10 +32,7 @@ d <- diamonds[sample(nrow(diamonds), 1000), ]
 p3 <- qplot(carat, price, group = cut, data = d) + geom_smooth()
 
 test_that("geom_smooth() respects group aesthetic", {
-  # 1 trace for points
-  # 5 traces for lines (1 for each group)
-  # 5 traces for ribbons (1 for each group)
-  info <- expect_traces(p3, 11, "group")
+  info <- expect_traces(p3, 3, "group")
 })
 
 p4 <- qplot(carat, price, colour = cut, data = d) + geom_smooth()

--- a/tests/testthat/test-ggplot-smooth.R
+++ b/tests/testthat/test-ggplot-smooth.R
@@ -35,17 +35,17 @@ test_that("geom_smooth() respects group aesthetic", {
   # 1 trace for points
   # 5 traces for lines (1 for each group)
   # 5 traces for ribbons (1 for each group)
-  expect_traces(p3, 11, "group")
+  info <- expect_traces(p3, 11, "group")
 })
 
 p4 <- qplot(carat, price, colour = cut, data = d) + geom_smooth()
 
 test_that("geom_smooth() respects colour aesthetic", {
-  expect_traces(p4, 11, "colour")
+  info <- expect_traces(p4, 11, "colour")
 })
 
 p5 <- qplot(carat, price, fill = cut, data = d) + geom_smooth()
 
 test_that("geom_smooth() respects fill aesthetic", {
-  expect_traces(p5, 11, "fill")
+  info <- expect_traces(p5, 11, "fill")
 })

--- a/tests/testthat/test-ggplot-smooth.R
+++ b/tests/testthat/test-ggplot-smooth.R
@@ -1,18 +1,51 @@
 context("smooth")
 
+expect_traces <- function(gg, n.traces, name){
+  stopifnot(is.ggplot(gg))
+  stopifnot(is.numeric(n.traces))
+  save_outputs(gg, paste0("smooth-", name))
+  L <- gg2list(gg)
+  is.trace <- names(L) == ""
+  all.traces <- L[is.trace]
+  no.data <- sapply(all.traces, function(tr) {
+    is.null(tr[["x"]]) && is.null(tr[["y"]])
+  })
+  has.data <- all.traces[!no.data]
+  expect_equal(length(has.data), n.traces)
+  list(traces=has.data, kwargs=L$kwargs)
+}
+
 p <- ggplot(mtcars, aes(mpg, wt)) + geom_point() + geom_smooth()
 
 test_that("geom_point() + geom_smooth() produces 3 traces", {
-  info <- gg2list(p)
-  expect_true(sum(names(info) == "") == 3)
-  save_outputs(p, "smooth")
+  expect_traces(p, 3, "basic")
 })
 
-p2 <- ggplot(mtcars, aes(mpg, wt)) + geom_point() + geom_smooth(se = FALSE)
+p2 <- ggplot(mtcars, aes(mpg, wt)) + geom_point() + 
+  geom_smooth(se = FALSE)
 
 test_that("geom_point() + geom_smooth(se = FALSE) produces 2 traces", {
-  info2 <- gg2list(p2)
-  expect_true(sum(names(info2) == "") == 2)
-  save_outputs(p2, "smooth-se-false")
+  expect_traces(p2, 2, "se-false")
 })
 
+d <- diamonds[sample(nrows(diamonds, 1000)), ]
+p3 <- qplot(carat, price, group = cut, data = d) + geom_smooth()
+
+test_that("geom_smooth() respects group aesthetic", {
+  # 1 trace for points
+  # 5 traces for lines (1 for each group)
+  # 5 traces for ribbons (1 for each group)
+  expect_traces(p3, 11, "group")
+})
+
+p4 <- qplot(carat, price, colour = cut, data = d) + geom_smooth()
+
+test_that("geom_smooth() respects colour aesthetic", {
+  expect_traces(p4, 11, "colour")
+})
+
+p5 <- qplot(carat, price, fill = cut, data = d) + geom_smooth()
+
+test_that("geom_smooth() respects fill aesthetic", {
+  expect_traces(p5, 11, "fill")
+})

--- a/tests/testthat/test-ggplot-smooth.R
+++ b/tests/testthat/test-ggplot-smooth.R
@@ -36,13 +36,37 @@ test_that("geom_smooth() respects group aesthetic", {
 })
 
 p4 <- qplot(carat, price, colour = cut, data = d) + geom_smooth()
+p5 <- qplot(carat, price, data = d) + geom_smooth(aes(colour = cut))
 
 test_that("geom_smooth() respects colour aesthetic", {
   info <- expect_traces(p4, 11, "colour")
+  # number of showlegends should equal the number of factor levels 
+  n <- sum(unlist(sapply(info$traces, "[[", "showlegend")))
+  expect_equal(n, nlevels(d$cut))
+  info <- expect_traces(p5, 11, "colour2")
+  n <- sum(unlist(sapply(info$traces, "[[", "showlegend")))
+  expect_equal(n, nlevels(d$cut))
 })
 
-p5 <- qplot(carat, price, fill = cut, data = d) + geom_smooth()
+# why are 5 traces for point being created here??
+#p6 <- qplot(carat, price, fill = cut, data = d) + geom_smooth()
+p7 <- qplot(carat, price, data = d) + geom_smooth(aes(fill = cut))
 
 test_that("geom_smooth() respects fill aesthetic", {
-  info <- expect_traces(p5, 11, "fill")
+#   info <- expect_traces(p6, 11, "fill")
+#   n <- sum(unlist(sapply(info$traces, "[[", "showlegend")))
+#   expect_equal(n, nlevels(d$cut))
+  info <- expect_traces(p7, 11, "fill2")
+  n <- sum(unlist(sapply(info$traces, "[[", "showlegend")))
+  expect_equal(n, nlevels(d$cut))
 })
+
+# ensure legend is drawn when needed
+p8 <- qplot(carat, price, data = d) + facet_wrap(~cut) + 
+  geom_smooth(aes(colour = cut, fill = cut))
+
+test_that("geom_smooth() works with facets", {
+  # 3 traces for each panel
+  info <- expect_traces(p8, 15, "fill2")
+})
+

--- a/tests/testthat/test-ggplot-smooth.R
+++ b/tests/testthat/test-ggplot-smooth.R
@@ -63,5 +63,7 @@ p8 <- qplot(carat, price, data = d) + facet_wrap(~cut) +
 test_that("geom_smooth() works with facets", {
   # 3 traces for each panel
   info <- expect_traces(p8, 15, "facet")
+  n <- sum(unlist(sapply(info$traces, "[[", "showlegend")))
+  expect_equal(n, nlevels(d$cut))
 })
 

--- a/tests/testthat/test-ggplot-smooth.R
+++ b/tests/testthat/test-ggplot-smooth.R
@@ -28,7 +28,7 @@ test_that("geom_point() + geom_smooth(se = FALSE) produces 2 traces", {
   expect_traces(p2, 2, "se-false")
 })
 
-d <- diamonds[sample(nrows(diamonds, 1000)), ]
+d <- diamonds[sample(nrow(diamonds), 1000), ]
 p3 <- qplot(carat, price, group = cut, data = d) + geom_smooth()
 
 test_that("geom_smooth() respects group aesthetic", {

--- a/tests/testthat/test-ggplot-smooth.R
+++ b/tests/testthat/test-ggplot-smooth.R
@@ -43,20 +43,15 @@ test_that("geom_smooth() respects colour aesthetic", {
   # number of showlegends should equal the number of factor levels 
   n <- sum(unlist(sapply(info$traces, "[[", "showlegend")))
   expect_equal(n, nlevels(d$cut))
-  info <- expect_traces(p5, 11, "colour2")
+  info <- expect_traces(p5, 7, "colour2")
   n <- sum(unlist(sapply(info$traces, "[[", "showlegend")))
   expect_equal(n, nlevels(d$cut))
 })
 
-# why are 5 traces for point being created here??
-#p6 <- qplot(carat, price, fill = cut, data = d) + geom_smooth()
 p7 <- qplot(carat, price, data = d) + geom_smooth(aes(fill = cut))
 
 test_that("geom_smooth() respects fill aesthetic", {
-#   info <- expect_traces(p6, 11, "fill")
-#   n <- sum(unlist(sapply(info$traces, "[[", "showlegend")))
-#   expect_equal(n, nlevels(d$cut))
-  info <- expect_traces(p7, 11, "fill2")
+  info <- expect_traces(p7, 7, "fill2")
   n <- sum(unlist(sapply(info$traces, "[[", "showlegend")))
   expect_equal(n, nlevels(d$cut))
 })


### PR DESCRIPTION
This pull request re-implements ribbon as a basic polygon (in a similar fashion to [rect](https://github.com/ropensci/plotly/pull/178)).

One major benefit of doing so is that `geom_ribbon()` (and consequently `geom_smooth()`)  will respect fill/colour/group aesthetics.