### PR TITLE
Bump version to 0.6 since change was backwards incompatible

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: plotly
 Type: Package
 Title: Interactive, publication-quality graphs online.
-Version: 0.5.30
+Version: 0.6
 Authors@R: c(person("Chris", "Parmer", role = c("aut", "cre"),
     email = "chris@plot.ly"),
     person("Scott", "Chamberlain", role = "aut",

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
-0.5.30 -- 4 May 2015
+0.6 -- 4 May 2015
 
-Let gg2list() return a figure object.
+Let gg2list() return a figure object (backwards incompatible change).
 
 0.5.29 -- 16 April 2015
 

--- a/R/plotly-package.r
+++ b/R/plotly-package.r
@@ -7,7 +7,7 @@
 #' \itemize{
 #'  \item Package: plotly
 #'  \item Type: Package
-#'  \item Version: 0.5.30
+#'  \item Version: 0.6
 #'  \item Date: 2014-03-07
 #'  \item License: MIT
 #' }

--- a/R/plotly.R
+++ b/R/plotly.R
@@ -82,7 +82,7 @@ For more help, see https://plot.ly/R or contact <chris@plot.ly>.")
   
   # public attributes/methods that the user has access to
   pub <- list(username=username, key=key, filename="from api", fileopt=NULL,
-              version="0.5.30")
+              version="0.6")
   priv <- list()
   
   pub$makecall <- function(args, kwargs, origin) {

--- a/man/plotly-package.Rd
+++ b/man/plotly-package.Rd
@@ -15,7 +15,7 @@ An example of an interactive graph made from the R API: https://plot.ly/~chris/4
 \itemize{
  \item Package: plotly
  \item Type: Package
- \item Version: 0.5.30
+ \item Version: 0.6
  \item Date: 2014-03-07
  \item License: MIT
 }


### PR DESCRIPTION
Follow @cpsievert 's suggestion to respect semantic versioning (should be part of https://github.com/ropensci/plotly/pull/210).

/cc @chriddyp @cldougl @13bzhang