### PR TITLE
remove `url_ok` check since it won't work with proxy logins

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -10,7 +10,7 @@
 print.plotly <- function(x, ...) {
   l <- plotly_POST(x)
   if (!is.null(l$url)) {
-    if (httr::url_ok(l$url) && interactive()) browseURL(l$url)
+    if (interactive()) browseURL(l$url)
   }
   # get_figure() instead?
   invisible(l)


### PR DESCRIPTION
and anyways, let the user see the appropriate http status response by visiting the web page and seeing the server's response

fixes #251 

cc @cpsievert @mkcor 