### PR TITLE
Loading dependency "viridis"

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,7 @@
+.onLoad <- function(libname, pkgname) {
+  if ("viridis" %in% rownames(installed.packages())) {
+    require("viridis", quietly = TRUE)
+  } else{
+    install.packages("viridis", type = "source")
+  }
+}


### PR DESCRIPTION
This is a temporary fix for loading dependency "viridis." I created a zzz.R file with a onLoad funciton that checks if `viridis` is installed. If not installed, I tell it to install it from `type = "source"`. 