### PR TITLE
maybe fix japanese file read error

### DIFF
--- a/R/offline.R
+++ b/R/offline.R
@@ -114,6 +114,6 @@ get_browser <- function() {
   # default web browser
   if (is.null(browseR) || !is.function(browseR) ||
       inherits(try(browseR('http://www.rstudio.com'), silent = TRUE), 'try-error'))
-    browseR = getOption("browser")
+    browseR = browseURL
   browseR
 }

--- a/R/print.R
+++ b/R/print.R
@@ -62,7 +62,7 @@ print.offline <- function(x, ...) {
   }
   index <- file.path(d, "index.html")
   res <- writeLines(html, index)
-  if (!is.null(x$viewer)) x$viewer(index)
+  if (is.function(x$viewer)) x$viewer(index)
 }
 
 #' Embed a plotly iframe into an R markdown document via \code{knit_print}


### PR DESCRIPTION
file.info returns file size in bytes

`useBytes` - logical: For readChar, should nchars be regarded as a
number of bytes not characters in a multi-byte locale?

This *may* fix an issue
```
In readChar(off, file.info(off)$size) :
can only read in bytes in a non-UTF-8 MBCS locale
```
from a user with a Japanese environment