### PR TITLE
fix filename, fileopt arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: plotly
 Title: Create interactive web-based graphs via plotly's API
-Version: 1.0.8
+Version: 1.0.9
 Authors@R: c(person("Chris", "Parmer", role = c("aut", "cph"),
     email = "chris@plot.ly"),
     person("Scott", "Chamberlain", role = "aut",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+1.0.9 -- 28 Sep 2015
+
+Fixed filename, fileopt arguments in plot_ly. Specifying the same filename will now overwrite the plot if it exists.
+
 1.0.8 -- 14 Sep 2015
 
 Added the plotly_IMAGES() function which interfaces to the images endpoint https://api.plot.ly/v2/#images

--- a/R/plotly.R
+++ b/R/plotly.R
@@ -316,10 +316,8 @@ plotly_build <- function(l = last_plot()) {
   }
   # search for keyword args in traces and place them at the top level
   kwargs <- lapply(x$data, function(z) z[get_kwargs()])
-  # later keywords args take precedence
-  kwargs <- Reduce(modifyList, kwargs)
-  # apply kwargs supplied in the call signature
-  kwargs[get_kwargs()] <- x[get_kwargs()]
+  # 'top-level' keywords args take precedence
+  kwargs <- Reduce(modifyList, c(kwargs, list(x[get_kwargs()])))
   # empty keyword arguments can cause problems
   kwargs <- kwargs[sapply(kwargs, length) > 0]
   # filename & fileopt are keyword arguments required by the API
@@ -338,8 +336,8 @@ plotly_build <- function(l = last_plot()) {
       ) %||%
       "plot from api" 
   }
-  # place kwargs back into x
-  x[get_kwargs()] = kwargs[get_kwargs()]
+  # tack on keyword arguments
+  x <- c(x, kwargs)
   # traces shouldn't have any names
   x$data <- setNames(x$data, NULL)
   # add plotly class mainly for printing method

--- a/R/plotly.R
+++ b/R/plotly.R
@@ -318,6 +318,8 @@ plotly_build <- function(l = last_plot()) {
   kwargs <- lapply(x$data, function(z) z[get_kwargs()])
   # later keywords args take precedence
   kwargs <- Reduce(modifyList, kwargs)
+  # apply kwargs supplied in the call signature
+  kwargs[get_kwargs()] <- x[get_kwargs()]
   # empty keyword arguments can cause problems
   kwargs <- kwargs[sapply(kwargs, length) > 0]
   # filename & fileopt are keyword arguments required by the API
@@ -336,6 +338,8 @@ plotly_build <- function(l = last_plot()) {
       ) %||%
       "plot from api" 
   }
+  # place kwargs back into x
+  x[get_kwargs()] = kwargs[get_kwargs()]
   # traces shouldn't have any names
   x$data <- setNames(x$data, NULL)
   # add plotly class mainly for printing method


### PR DESCRIPTION
hey @cpsievert  -- looks like the refactor in https://github.com/ropensci/plotly/commit/0b2eeb9692a2dfd69a596252e3b4a1f82db973c6 missed a couple things with the filename kwarg. since that commit, specifying the same filename doesn't overwrite the graph:

```
> d <- diamonds[sample(nrow(diamonds), 1000), ]
> p <- plot_ly(d, x = carat, y = price, text = paste("Clarity: ", clarity), filename="test")
> p
Success! Created a new plotly here -> https://plot.ly/~christopherp/1310
> p <- plot_ly(d, x = carat, y = price, text = paste("Clarity: ", clarity), filename="test")
> p
Success! Created a new plotly here -> https://plot.ly/~christopherp/1312
```

here's a fix.

cc @cldougl