### PR TITLE
RFC: fix traces subdivision by multiple properties

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,9 +31,9 @@ Imports:
     base64enc,
     htmlwidgets,
     tidyr,
+    dplyr,
     hexbin
 Suggests:
-    dplyr,
     maps,
     ggthemes,
     GGally,

--- a/tests/testthat/test-plotly-subplot.R
+++ b/tests/testthat/test-plotly-subplot.R
@@ -29,11 +29,11 @@ test_that("nrows argument works", {
   expect_true(doms$yaxis2[2] > doms$yaxis2[1])
 })
 
-test_that("group + [x/y]axis works", {
+test_that("color + [x/y]axis works", {
   iris$id <- as.integer(iris$Species)
-  p <- plot_ly(iris, x = Petal.Length, y = Petal.Width, group = Species,
+  p <- plot_ly(iris, x = Petal.Length, y = Petal.Width, color = Species,
                xaxis = paste0("x", id), mode = "markers")
-  s <- expect_traces(subplot(p, margin = 0.05), 3, "group")
+  s <- expect_traces(subplot(p, margin = 0.05), 3, "color")
   ax <- s$layout[grepl("^[x-y]axis", names(s$layout))]
   doms <- lapply(ax, "[[", "domain")
   # make sure y domain is [0, 1] on every axis

--- a/tests/testthat/test-plotly.R
+++ b/tests/testthat/test-plotly.R
@@ -17,11 +17,12 @@ test_that("plot_ly() handles a simple scatterplot", {
   expect_identical(l$layout$yaxis$title, "Petal.Length")
 })
 
-test_that("Using group argument creates multiple traces", {
-  p <- plot_ly(data = iris, x = Sepal.Length, y = Petal.Length, group = Species)
-  l <- expect_traces(p, 3, "scatterplot-group")
+test_that("Using group argument doesn't transform the data in markers mode", {
+  p <- plot_ly(data = iris, x = Sepal.Length, y = Petal.Length, group = Species, mode = "markers")
+  l <- expect_traces(p, 1, "scatterplot-group-markers")
   expect_identical(l$layout$xaxis$title, "Sepal.Length")
   expect_identical(l$layout$yaxis$title, "Petal.Length")
+  expect_identical(l$data[[1]]$group, iris$Species)
 })
 
 test_that("Mapping a variable to symbol works", {
@@ -29,7 +30,7 @@ test_that("Mapping a variable to symbol works", {
   l <- expect_traces(p, 3, "scatterplot-symbol")
   markers <- lapply(l$data, "[[", "marker")
   syms <- unlist(lapply(markers, "[[", "symbol"))
-  expect_identical(syms, c("dot", "cross", "diamond"))
+  expect_identical(syms, rev(c("dot", "cross", "diamond"))) # rev() because traces are drawn in reverse order (higher to lower)
 })
 
 test_that("Mapping a factor variable to color works", {

--- a/tests/testthat/test-plotly.R
+++ b/tests/testthat/test-plotly.R
@@ -25,6 +25,20 @@ test_that("Using group argument doesn't transform the data in markers mode", {
   expect_identical(l$data[[1]]$group, iris$Species)
 })
 
+test_that("Using group argument for scatter plot in lines mode introduces breaks (NA values separating different groups)", {
+  p <- plot_ly(data = iris, x = Sepal.Length, y = Petal.Length, group = Species, mode = "lines")
+  l <- expect_traces(p, 1, "scatterplot-group-lines")
+  expect_identical(l$layout$xaxis$title, "Sepal.Length")
+  expect_identical(l$layout$yaxis$title, "Petal.Length")
+  n_groups <- length(unique(iris$Species))
+  n_pts <- length(l$data[[1]]$x)
+  expect_identical(n_pts, nrow(iris)+n_groups-1L)
+  expect_identical(sum(is.na(l$data[[1]]$x)), n_groups-1L)
+  expect_true(all(is.na(l$data[[1]]$group[-1]) |
+                  is.na(l$data[[1]]$group[-n_pts]) |
+                  (l$data[[1]]$group[-1] == l$data[[1]]$group[-n_pts])))
+})
+
 test_that("Mapping a variable to symbol works", {
   p <- plot_ly(data = iris, x = Sepal.Length, y = Petal.Length, symbol = Species)
   l <- expect_traces(p, 3, "scatterplot-symbol")


### PR DESCRIPTION
This is my version of the #418 fix:
- add `indices` property to the trace to reference the indices of
  the data elements associated with the trace
- replace `tracify()` by `subdivide_traces()` that correctly subdivides
  the current set of traces based on the given data property

Note that while the traces are assigned the correct visual properties, the PR does not fix #381 -- individual `group` traces are still being created and displayed in the legend.

Comments, especially regarding the ways to fix #381 are most welcome.