### PR TITLE
use Plotly axis titles if not facetted

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: plotly
 Title: Create Interactive Web Graphics via 'plotly.js'
-Version: 3.5.4
+Version: 3.5.5
 Authors@R: c(person("Carson", "Sievert", role = c("aut", "cre"),
     email = "cpsievert1@gmail.com"),
     person("Chris", "Parmer", role = c("aut", "cph"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,15 @@
+3.5.5 -- 5 May 2016
+
+CHANGES:
+
+ggplotly() will now use plotly's layout.axisid.title (instead of 
+layout.annotations) for axis titles on non-faceted plots. 
+This will make for a better title placement experience (see #510).
+
+BUG FIX:
+
+Space for interior facet_wrap() strips are now accounted for.
+
 3.5.4 -- 5 May 2016
 
 BUG FIX:

--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -353,7 +353,7 @@ gg2list <- function(p, width = NULL, height = NULL, tooltip = "all", source = "A
         ticklen = unitConvert(theme$axis.ticks.length, "pixels", type),
         tickwidth = unitConvert(axisTicks, "pixels", type),
         showticklabels = !is_blank(axisText),
-        tickfont = text2font(axisText, "height"),
+        tickfont = text2font(axisText, type),
         tickangle = - (axisText$angle %||% 0),
         showline = !is_blank(axisLine),
         linecolor = toRGB(axisLine$colour),
@@ -364,9 +364,8 @@ gg2list <- function(p, width = NULL, height = NULL, tooltip = "all", source = "A
         gridwidth = unitConvert(panelGrid, "pixels", type),
         zeroline = FALSE,
         anchor = anchor,
-        #  if not facets then use Plotly axis titling mechanism
-        #   see https://github.com/ropensci/plotly/issues/510
-        title = axisTitleText
+        title = axisTitleText,
+        titlefont = text2font(axisTitle)
       )
       # convert dates to milliseconds (86400000 = 24 * 60 * 60 * 1000)
       # this way both dates/datetimes are on same scale
@@ -413,8 +412,9 @@ gg2list <- function(p, width = NULL, height = NULL, tooltip = "all", source = "A
           if (xy == "y" && inherits(p$facet, "grid")) {
             gglayout$margin$r <- gglayout$margin$r + stripSize
           }
-          # draw axis titles as annotations
-          # (plotly.js axis titles aren't smart enough to dodge ticks & text)
+          # facets have multiple axis objects, but only one title for the plot,
+          # so we empty the titles and try to draw the title as an annotation
+          gglayout[[axisName]]$title <- ""
           if (nchar(axisTitleText) > 0) {
             # npc is on a 0-1 scale of the _entire_ device,
             # but these units _should_ be wrt to the plotting region
@@ -432,13 +432,6 @@ gg2list <- function(p, width = NULL, height = NULL, tooltip = "all", source = "A
           }
         }
       }
-      
-      if (has_facet(p)) {
-        # turn off plotly axis titles
-        #  since we need special treatment for facets
-        gglayout[[axisName]]$title <- ""
-      }
-
     } # end of axis loop
 
     xdom <- gglayout[[lay[, "xaxis"]]]$domain

--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -277,6 +277,7 @@ gg2list <- function(p, width = NULL, height = NULL, tooltip = "all", source = "A
       theme[["strip.text.x"]] %||% theme[["strip.text"]],
       "npc", "height"
     )
+    panelMarginY <- panelMarginY + stripSize
     # space for ticks/text in free scales
     if (p$facet$free$x) {
       axisTicksX <- unitConvert(
@@ -307,7 +308,6 @@ gg2list <- function(p, width = NULL, height = NULL, tooltip = "all", source = "A
     rep(panelMarginX, 2),
     rep(panelMarginY, 2)
   )
-  
   doms <- get_domains(nPanels, nRows, margins)
 
   for (i in seq_len(nPanels)) {
@@ -414,7 +414,6 @@ gg2list <- function(p, width = NULL, height = NULL, tooltip = "all", source = "A
           }
           # facets have multiple axis objects, but only one title for the plot,
           # so we empty the titles and try to draw the title as an annotation
-          gglayout[[axisName]]$title <- ""
           if (nchar(axisTitleText) > 0) {
             # npc is on a 0-1 scale of the _entire_ device,
             # but these units _should_ be wrt to the plotting region
@@ -432,6 +431,11 @@ gg2list <- function(p, width = NULL, height = NULL, tooltip = "all", source = "A
           }
         }
       }
+      
+      if (has_facet(p)) {
+        gglayout[[axisName]]$title <- ""
+      }
+      
     } # end of axis loop
 
     xdom <- gglayout[[lay[, "xaxis"]]]$domain

--- a/tests/testthat/test-cookbook-axes.R
+++ b/tests/testthat/test-cookbook-axes.R
@@ -107,7 +107,7 @@ no.x.title <- bp +
 
 test_that("coord_fixed(ratio)", {
   info <- expect_traces(no.x.title, 1, "no-x-title")
-  expect_true(length(info$layout$annotations) == 1)
+  expect_identical(info$xaxis$title, "")
 })
 
 # Also possible to set the axis label with the scale

--- a/tests/testthat/test-cookbook-axes.R
+++ b/tests/testthat/test-cookbook-axes.R
@@ -107,7 +107,7 @@ no.x.title <- bp +
 
 test_that("coord_fixed(ratio)", {
   info <- expect_traces(no.x.title, 1, "no-x-title")
-  expect_identical(info$xaxis$title, "")
+  expect_identical(info$layout$xaxis$title, "")
 })
 
 # Also possible to set the axis label with the scale

--- a/tests/testthat/test-ggplot-labels.R
+++ b/tests/testthat/test-ggplot-labels.R
@@ -13,8 +13,8 @@ test_that("ylab is translated correctly", {
     geom_point(aes(Petal.Width, Sepal.Width)) +
     ylab("sepal width")
   info <- save_outputs(ggiris, "labels-ylab")
-  labs <- unlist(lapply(info$layout$annotations, "[[", "text"))
-  expect_identical(sort(labs), c("Petal.Width", "sepal width"))
+  labs <- c(info$layout$xaxis$title, info$layout$yaxis$title)
+  expect_identical(labs, c("Petal.Width", "sepal width"))
 })
 
 # TODO: why is this failing on R-devel???

--- a/tests/testthat/test-ggplot-legend.R
+++ b/tests/testthat/test-ggplot-legend.R
@@ -30,9 +30,9 @@ test_that("Discrete colour and shape get merged into one legend", {
     nms, paste0("(", d$vs, ",", d$cyl, ")")
   )
   a <- info$layout$annotations
-  expect_match(a[[3]]$text, "^factor\\(vs\\)")
-  expect_match(a[[3]]$text, "factor\\(cyl\\)$")
-  expect_true(a[[3]]$y > info$layout$legend$y)
+  expect_match(a[[1]]$text, "^factor\\(vs\\)")
+  expect_match(a[[1]]$text, "factor\\(cyl\\)$")
+  expect_true(a[[1]]$y > info$layout$legend$y)
 })
 
 


### PR DESCRIPTION
Closes #573 to pull from ropensci remote.  Also rebase to current master.

As reported in #510, axis titles can be positioned improperly depending on the size of the plot.  In a2aedacd0900bf6f447d72e3f174deb4d8cfbc91, axis titles were changed to annotations, so they are not duplicated and work much more similarly to `ggplot2`.  Unfortunately, `plotly` annotations are positioned based on a `[0,1]` scale with respect to the plot area.  This means the axis titles scale inversely and negatively to the plot size.  When the plot is small, the `x` axis title will be placed too high.  When the plot is large/high, the `x` axis title moves too far down sometimes out of the svg bounding box.

This pull changes to use `plotly` axis titles when the plot is not facetted.  When the plot is facetted, the `plotly` axis titles are changed to `""` in favor of the annotation approach.