### PR TITLE
Fix the axes layout for facet grid/wrap.

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -212,10 +212,11 @@ gg2list <- function(p, width = NULL, height = NULL, tooltip = "all", source = "A
     }
   }
   # format the axis/anchor to a format plotly.js respects
-  panel$layout$xaxis <- paste0("xaxis", sub("1", "", panel$layout$xaxis))
-  panel$layout$yaxis <- paste0("yaxis", sub("1", "", panel$layout$yaxis))
-  panel$layout$xanchor <- paste0("y", sub("1", "", panel$layout$xanchor))
-  panel$layout$yanchor <- paste0("x", sub("1", "", panel$layout$yanchor))
+  plotlyjs_axis_label <- function(prefix, ixs) paste0(prefix, ifelse(as.integer(ixs) > 1, ixs, ""))
+  panel$layout$xaxis <- plotlyjs_axis_label("xaxis", panel$layout$xaxis)
+  panel$layout$yaxis <- plotlyjs_axis_label("yaxis", panel$layout$yaxis)
+  panel$layout$xanchor <- plotlyjs_axis_label("y", panel$layout$xanchor)
+  panel$layout$yanchor <- plotlyjs_axis_label("x", panel$layout$yanchor)
   # for some layers2traces computations, we need the range of each panel
   panel$layout$x_min <- sapply(panel$ranges, function(z) min(z$x.range))
   panel$layout$x_max <- sapply(panel$ranges, function(z) max(z$x.range))

--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -191,10 +191,12 @@ gg2list <- function(p, width = NULL, height = NULL, tooltip = "all", source = "A
 
   # panel -> plotly.js axis/anchor info
   # (assume a grid layout by default)
-  panel$layout$xaxis <- panel$layout$COL
-  panel$layout$yaxis <- panel$layout$ROW
-  panel$layout$xanchor <- nRows
-  panel$layout$yanchor <- 1
+  panel$layout <- dplyr::mutate( panel$layout,
+    xaxis = COL, yaxis = ROW,
+    yanchor = 1L ) %>%
+    dplyr::group_by( xaxis ) %>%
+    dplyr::mutate( xanchor = max(ROW) ) %>% # anchor X axis to the lowest plot in the column
+    dplyr::ungroup() %>% as.data.frame()
   if (inherits(p$facet, "wrap")) {
     if (p$facet$free$x) {
       panel$layout$xaxis <- panel$layout$PANEL


### PR DESCRIPTION
The PR fixes the labels of axes/anchors if the corresponding indices are >= 10 (otherwise the data/gridlines in some panels are missing). 

For a test one can try
```R
p <- ggplot( data.frame(x = rnorm(1000), y = rnorm(1000),
                   a = sample(1:20, 1000, replace=TRUE) ) ) +
  geom_point(aes(x=x, y=y)) + facet_wrap(~ a, scales = "free_x" )
ggplotly(p)
```

The PR fixes the behaviour for `scales="free"` and `scales="free_x"` case. For `scales="free_y"` case it fixes the missing panels, but the X axes at the bottom are still missing.