### PR TITLE
Piecharts: "plotly.js:53Uncaught TypeError: Cannot read property 'hasOwnProperty' of undefined" 

### DIFF
--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -50,7 +50,7 @@ HTMLWidgets.widget({
           var tr = x.data[pt.curveNumber];
           // add on additional trace info, if it exists
           attachKey = function(keyName) {
-            if (tr.hasOwnProperty(keyName) && tr[keyName] !== null) {
+            if (tr !== undefined && tr.hasOwnProperty(keyName) && tr[keyName] !== null) {
               if (typeof pt.pointNumber === "number") {
                 obj[keyName] = tr[keyName][pt.pointNumber];
               } else {


### PR DESCRIPTION
An error occurred for pie charts with hoverinfo in HTMLWidgets.widget. I m not a web dev and i solved with a logical statement 

This is the error with mouse over the chart's pieces:

![image](https://cloud.githubusercontent.com/assets/3137038/17358958/d3b78800-5964-11e6-95e1-199e210df925.png)

![image](https://cloud.githubusercontent.com/assets/3137038/17358985/ee998c54-5964-11e6-921f-fad113c7c877.png)

I'm creating a shiny app, this is the log after changes made

![image](https://cloud.githubusercontent.com/assets/3137038/17359136/84fb26bc-5965-11e6-947c-18e6f21a26e7.png)

Thks for your help
