### PR TITLE
Updates to better support dendrograms

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -702,6 +702,7 @@ gg2list <- function(p, width = NULL, height = NULL, tooltip = "all",
   )
   
   # if theme(legend.position = "none") is used, don't show a legend _or_ guide
+  npscales$scales <- Filter(function(x) x$guide != "none", npscales$scales)
   if (npscales$n() == 0 || identical(theme$legend.position, "none")) {
     gglayout$showlegend <- FALSE
   } else {

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -260,6 +260,29 @@ to_basic.GeomRect <- function(data, prestats_data, layout, params, p, ...) {
           cbind(x = xmax, y = ymax, others),
           cbind(x = xmax, y = ymin, others))
   })
+  if (layout$xanchor == "x") {
+    dat <- with(data, {
+      rbind(cbind(x = ifelse(xmin == -Inf, layout$x_min, xmin),
+                  y = ifelse(ymin == -Inf, layout$y_min, ymin), others),
+            cbind(x = ifelse(xmin == -Inf, layout$x_min, xmin),
+                  y = ifelse(ymax == Inf, layout$y_max, ymax), others),
+            cbind(x = ifelse(xmax == -Inf, layout$x_max, xmax),
+                  y = ifelse(ymax == Inf, layout$y_max, ymax), others),
+            cbind(x = ifelse(xmax == -Inf, layout$x_max, xmax),
+                  y = ifelse(ymin == -Inf, layout$y_min, ymin), others))
+    })
+  } else {
+    dat <- with(data, {
+      rbind(cbind(x = ifelse(xmin == -Inf, layout$y_min, xmin),
+                  y = ifelse(ymin == -Inf, layout$x_min, ymin), others),
+            cbind(x = ifelse(xmin == -Inf, layout$y_min, xmin),
+                  y = ifelse(ymax == Inf, layout$x_max, ymax), others),
+            cbind(x = ifelse(xmax == -Inf, layout$y_max, xmax),
+                  y = ifelse(ymax == Inf, layout$x_max, ymax), others),
+            cbind(x = ifelse(xmax == -Inf, layout$y_max, xmax),
+                  y = ifelse(ymin == -Inf, layout$x_min, ymin), others))
+    })
+  }
   prefix_class(dat, c("GeomPolygon", "GeomRect"))
 }
 
@@ -603,10 +626,21 @@ geom2trace.GeomBoxplot <- function(data, params, p) {
 
 #' @export
 geom2trace.GeomText <- function(data, params, p) {
+  text <- as.character(data[["label"]])
   compact(list(
     x = data[["x"]],
     y = data[["y"]],
-    text = data[["label"]],
+    text = ifelse(
+      grepl("bold", data[["fontface"]]),
+      paste0("<b>",
+             ifelse(
+               grepl("italic", data[["fontface"]]),
+               paste0("<i>", text, "</i>"),
+               text
+             ),
+             "</b>"),
+      text
+    ),
     key = data[["key"]],
     frame = data[["frame"]],
     ids = data[["ids"]],
@@ -616,6 +650,14 @@ geom2trace.GeomText <- function(data, params, p) {
       color = toRGB(
         aes2plotly(data, params, "colour"),
         aes2plotly(data, params, "alpha")
+      )
+    ),
+    textposition = paste0(
+      ifelse(data[["vjust"]] < 0.5, "top ",
+             ifelse(data[["vjust"]] > 0.5, "bottom ", "")
+      ),
+      ifelse(data[["hjust"]] < 0.5, "right ",
+             ifelse(data[["vjust"]] > 0.5, "left ", "center")
       )
     ),
     type = "scatter",

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -628,12 +628,12 @@ geom2trace.GeomBoxplot <- function(data, params, p) {
 geom2trace.GeomText <- function(data, params, p) {
   text <- as.character(data[["label"]])
   text <- ifelse(
-    grepl("bold", text),
+    grepl("bold", data[["fontface"]]),
     paste0("<b>", text, "</b>"),
     text
   )
   text <- ifelse(
-    grepl("italic", text),
+    grepl("italic", data[["fontface"]]),
     paste0("<i>", text, "</i>"),
     text
   )

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -656,8 +656,8 @@ geom2trace.GeomText <- function(data, params, p) {
       ifelse(data[["vjust"]] < 0.5, "top ",
              ifelse(data[["vjust"]] > 0.5, "bottom ", "")
       ),
-      ifelse(data[["hjust"]] < 0.5, "right ",
-             ifelse(data[["vjust"]] > 0.5, "left ", "center")
+      ifelse(data[["hjust"]] < 0.5, "right",
+             ifelse(data[["vjust"]] > 0.5, "left", "center")
       )
     ),
     type = "scatter",

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -266,9 +266,9 @@ to_basic.GeomRect <- function(data, prestats_data, layout, params, p, ...) {
                   y = ifelse(ymin == -Inf, layout$x_min, ymin), others),
             cbind(x = ifelse(xmin == -Inf, layout$y_min, xmin),
                   y = ifelse(ymax == Inf, layout$x_max, ymax), others),
-            cbind(x = ifelse(xmax == -Inf, layout$y_max, xmax),
+            cbind(x = ifelse(xmax == Inf, layout$y_max, xmax),
                   y = ifelse(ymax == Inf, layout$x_max, ymax), others),
-            cbind(x = ifelse(xmax == -Inf, layout$y_max, xmax),
+            cbind(x = ifelse(xmax == Inf, layout$y_max, xmax),
                   y = ifelse(ymin == -Inf, layout$x_min, ymin), others))
     })
   } else {
@@ -277,9 +277,9 @@ to_basic.GeomRect <- function(data, prestats_data, layout, params, p, ...) {
                   y = ifelse(ymin == -Inf, layout$y_min, ymin), others),
             cbind(x = ifelse(xmin == -Inf, layout$x_min, xmin),
                   y = ifelse(ymax == Inf, layout$y_max, ymax), others),
-            cbind(x = ifelse(xmax == -Inf, layout$x_max, xmax),
+            cbind(x = ifelse(xmax == Inf, layout$x_max, xmax),
                   y = ifelse(ymax == Inf, layout$y_max, ymax), others),
-            cbind(x = ifelse(xmax == -Inf, layout$x_max, xmax),
+            cbind(x = ifelse(xmax == Inf, layout$x_max, xmax),
                   y = ifelse(ymin == -Inf, layout$y_min, ymin), others))
     })
   }

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -260,18 +260,7 @@ to_basic.GeomRect <- function(data, prestats_data, layout, params, p, ...) {
           cbind(x = xmax, y = ymax, others),
           cbind(x = xmax, y = ymin, others))
   })
-  if (layout$xanchor == "x") {
-    dat <- with(data, {
-      rbind(cbind(x = ifelse(xmin == -Inf, layout$x_min, xmin),
-                  y = ifelse(ymin == -Inf, layout$y_min, ymin), others),
-            cbind(x = ifelse(xmin == -Inf, layout$x_min, xmin),
-                  y = ifelse(ymax == Inf, layout$y_max, ymax), others),
-            cbind(x = ifelse(xmax == -Inf, layout$x_max, xmax),
-                  y = ifelse(ymax == Inf, layout$y_max, ymax), others),
-            cbind(x = ifelse(xmax == -Inf, layout$x_max, xmax),
-                  y = ifelse(ymin == -Inf, layout$y_min, ymin), others))
-    })
-  } else {
+  if (inherits(p$coordinates, "CoordFlip")) {
     dat <- with(data, {
       rbind(cbind(x = ifelse(xmin == -Inf, layout$y_min, xmin),
                   y = ifelse(ymin == -Inf, layout$x_min, ymin), others),
@@ -281,6 +270,17 @@ to_basic.GeomRect <- function(data, prestats_data, layout, params, p, ...) {
                   y = ifelse(ymax == Inf, layout$x_max, ymax), others),
             cbind(x = ifelse(xmax == -Inf, layout$y_max, xmax),
                   y = ifelse(ymin == -Inf, layout$x_min, ymin), others))
+    })
+  } else {
+    dat <- with(data, {
+      rbind(cbind(x = ifelse(xmin == -Inf, layout$x_min, xmin),
+                  y = ifelse(ymin == -Inf, layout$y_min, ymin), others),
+            cbind(x = ifelse(xmin == -Inf, layout$x_min, xmin),
+                  y = ifelse(ymax == Inf, layout$y_max, ymax), others),
+            cbind(x = ifelse(xmax == -Inf, layout$x_max, xmax),
+                  y = ifelse(ymax == Inf, layout$y_max, ymax), others),
+            cbind(x = ifelse(xmax == -Inf, layout$x_max, xmax),
+                  y = ifelse(ymin == -Inf, layout$y_min, ymin), others))
     })
   }
   prefix_class(dat, c("GeomPolygon", "GeomRect"))

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -627,20 +627,20 @@ geom2trace.GeomBoxplot <- function(data, params, p) {
 #' @export
 geom2trace.GeomText <- function(data, params, p) {
   text <- as.character(data[["label"]])
+  text <- ifelse(
+    grepl("bold", text),
+    paste0("<b>", text, "</b>"),
+    text
+  )
+  text <- ifelse(
+    grepl("italic", text),
+    paste0("<i>", text, "</i>"),
+    text
+  )
   compact(list(
     x = data[["x"]],
     y = data[["y"]],
-    text = ifelse(
-      grepl("bold", data[["fontface"]]),
-      paste0("<b>",
-             ifelse(
-               grepl("italic", data[["fontface"]]),
-               paste0("<i>", text, "</i>"),
-               text
-             ),
-             "</b>"),
-      text
-    ),
+    text = text,
     key = data[["key"]],
     frame = data[["frame"]],
     ids = data[["ids"]],


### PR DESCRIPTION
These changes were made to better support dendrograms, particularly those created with `dendextend`.  It adds support for 
- `fontface` in `geom_text`
- a rough translation of `hjust` and `vjust` in `geom_text`
- `-Inf` and `Inf` in `geom_rect`
- `guide = "none"`

Feedback is very welcome.  Below is some sample code.
```
library(ggplot2)
library(plotly)
library(dendextend)

dend <- iris[1:30,-5] %>% dist %>% hclust %>% as.dendrogram %>%
  set("branches_k_color", k=3) %>% set("branches_lwd", c(1.5,1,1.5)) %>%
  set("branches_lty", c(1,1,3,1,1,2)) %>%
  set("labels_colors") %>% set("labels_cex", c(.9,1.2)) %>% 
  set("nodes_pch", 19) %>% set("nodes_col", c("orange", "black", "plum", NA))
ggd1 <- as.ggdend(dend)
p = ggplot(ggd1, horiz = TRUE, theme = NULL)
ggplotly(p)

p1 = ggplot(cars) +
  geom_point(aes(x = speed, y = dist)) +
  geom_rect(xmin = 5, xmax = 10, ymin = -Inf, ymax = Inf)
ggplotly(p1)

p2 = ggplot(cars) +
  geom_point(aes(x = speed, y = dist)) +
  geom_rect(ymin = 25, ymax = 50, xmin = -Inf, xmax = Inf)
ggplotly(p2)

p3 = ggplot(cars) +
  geom_point(aes(x = speed, y = dist)) +
  geom_rect(xmin = 5, xmax = 10, ymin = -Inf, ymax = Inf) +
  coord_flip()
ggplotly(p3)

p4 = ggplot(cars) +
  geom_point(aes(x = speed, y = dist)) +
  geom_rect(ymin = 25, ymax = 50, xmin = -Inf, xmax = Inf) +
  coord_flip()
ggplotly(p4)

p5 = ggplot(data.frame(x = seq(5, 25, 5), y = 60)) +
  geom_point(aes(x = x, y = y)) +
  geom_text(x = 5, y = 60, label = "nothing") +
  geom_text(x = 10, y = 60, label = "bold", fontface = "bold", hjust = 0, vjust = 0) +
  geom_text(x = 15, y = 60, label = "italic", fontface = "italic", hjust = 1, vjust = 1) +
  geom_text(x = 20, y = 60, label = "bold italic", fontface = "bold italic", hjust = 0, vjust = 1) +
  geom_text(x = 25, y = 60, label = "plain", fontface = "plain", hjust = 1, vjust = 0)
ggplotly(p5)
```