### PR TITLE
preventing too many active WebGL contexts

### DIFF
--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -57,7 +57,9 @@ HTMLWidgets.widget({
       
     } else {
       
-      var plot = Plotly.newPlot(graphDiv, x);
+      // using Plotly.newPlot creates new WebGL context, Plotly.redraw just redraws.
+      graphDiv.data = x.data; graphDiv.layout = x.layout; 
+      var plot = Plotly.redraw(graphDiv);
       
     }
     


### PR DESCRIPTION
Plotly makes one WebGL context per graph meaning that pages with multiple plotly WebGL graphs are exposed to the browser's context cap.  https://github.com/plotly/plotly.js/issues/337
So it is better to redraw the graph, rather than create a new one.
Thanks