### PR TITLE
What are the possible args for "off"?

### DIFF
--- a/R/highlight.R
+++ b/R/highlight.R
@@ -12,7 +12,7 @@
 #' 'plotly_hover', 'plotly_click', 'plotly_selected'. To disable on events 
 #' altogether, use \code{NULL}.
 #' @param off turn off a selection on which event(s)? Likely candidates are
-#' 'plotly_unhover', 'plotly_doubleclick', 'plotly_deselect'. To disable off 
+#' 'plotly_relayout', 'plotly_doubleclick', 'plotly_deselect'. To disable off 
 #' events altogether, use \code{NULL}.
 #' @param persistent should selections persist (i.e., accumulate)?
 #' @param dynamic should a widget for changing selection colors be included? 


### PR DESCRIPTION
The error message says it should be "plotly_relayout"

```
> highlight(ggplotly(p), on = "plotly_selected", off = 'plotly_unhover', persis = FALSE)
Error in match.arg(off, off_options) : 
  'arg' should be one of “plotly_doubleclick”, “plotly_deselect”, “plotly_relayout”
> 
```