### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,8 @@ Imports:
     lazyeval (>= 0.2.0),
     crosstalk,
     purrr,
-    data.table
+    data.table,
+    sf
 Suggests:
     MASS,
     maps,
@@ -61,7 +62,6 @@ Suggests:
     webshot,
     listviewer,
     dendextend,
-    sf,
     RSelenium,
     png,
     IRdisplay


### PR DESCRIPTION
Move sf from *suggests* to *imports*: it is not only required by tests now, sometimes call `gg2list()` may raise an error: `Error in loadNamespace(name) : there is no package called 'sf'`

Traceback:
```pre
40.
stop(e) 
39.
value[[3L]](cond) 
38.
tryCatchOne(expr, names, parentenv, handlers[[1L]]) 
37.
tryCatchList(expr, classes, parentenv, handlers) 
36.
tryCatch(loadNamespace(name), error = function(e) stop(e)) 
35.
getNamespace(ns) 
34.
asNamespace(ns) 
33.
getExportedValue(pkg, name) 
32.
sf::st_is_longlat 
31.
isTRUE(sf::st_is_longlat(rng$crs)) 
30.
gg2list(p, width = width, height = height, tooltip = tooltip, 
    dynamicTicks = dynamicTicks, layerData = layerData, originalData = originalData, 
    source = source, ...) 
29.
ggplotly.ggplot(p) 
28.
ggplotly(p) 
27.
eval(expr, envir, enclos) 
26.
eval(expr, envir, enclos) 
25.
withVisible(eval(expr, envir, enclos)) 
24.
withCallingHandlers(withVisible(eval(expr, envir, enclos)), warning = wHandler, 
    error = eHandler, message = mHandler) 
23.
handle(ev <- withCallingHandlers(withVisible(eval(expr, envir, 
    enclos)), warning = wHandler, error = eHandler, message = mHandler)) 
22.
timing_fn(handle(ev <- withCallingHandlers(withVisible(eval(expr, 
    envir, enclos)), warning = wHandler, error = eHandler, message = mHandler))) 
21.
evaluate_call(expr, parsed$src[[i]], envir = envir, enclos = enclos, 
    debug = debug, last = i == length(out), use_try = stop_on_error != 
        2L, keep_warning = keep_warning, keep_message = keep_message, 
    output_handler = output_handler, include_timing = include_timing) 
20.
evaluate::evaluate(...) 
19.
evaluate(code, envir = env, new_device = FALSE, keep_warning = !isFALSE(options$warning), 
    keep_message = !isFALSE(options$message), stop_on_error = if (options$error && 
        options$include) 0L else 2L, output_handler = knit_handlers(options$render, 
        options)) 
18.
in_dir(input_dir(), evaluate(code, envir = env, new_device = FALSE, 
    keep_warning = !isFALSE(options$warning), keep_message = !isFALSE(options$message), 
    stop_on_error = if (options$error && options$include) 0L else 2L, 
    output_handler = knit_handlers(options$render, options))) 
17.
block_exec(params) 
16.
call_block(x) 
15.
process_group.block(group) 
14.
process_group(group) 
13.
withCallingHandlers(if (tangle) process_tangle(group) else process_group(group), 
    error = function(e) {
        setwd(wd)
        cat(res, sep = "\n", file = output %n% "") ... 
12.
process_file(text, output) 
11.
knit(..., tangle = opts_knit$get("tangle"), envir = envir, encoding = opts_knit$get("encoding") %n% 
    getOption("encoding")) 
10.
FUN(X[[i]], ...) 
9.
lapply(sc_split(params$child), knit_child, options = block$params) 
8.
call_block(x) 
7.
process_group.block(group) 
6.
process_group(group) 
5.
withCallingHandlers(if (tangle) process_tangle(group) else process_group(group), 
    error = function(e) {
        setwd(wd)
        cat(res, sep = "\n", file = output %n% "") ... 
4.
process_file(text, output) 
3.
knitr::knit(knit_input, knit_output, envir = envir, quiet = quiet, 
    encoding = encoding) 
2.
rmarkdown::render(system.file(file.path("rmd", "reporter.Rmd"), 
    package = "LncPipeReporter"), output_dir = output_dir, output_options = list(lib_dir = file.path(output_dir, 
    "libs")), params = list(input = input, output = output, theme = theme, 
    cdf.percent = cdf.percent, max.lncrna.len = max.lncrna.len,  ... at run_reporter.R#52
1.
run_reporter() 
```

This occurred when I call `ggplotly()` to convert `ggplot2` object (generated by [ggbiplot](https://github.com/vqv/ggbiplot) indeed) to one as `plotly` in [my package](https://github.com/bioinformatist/LncPipeReporter/blob/master/inst/rmd/DE.Rmd).

`gg2list()` may [call functions in `sf` package](https://github.com/ropensci/plotly/blob/a75613ba3d0fc3638c50daf740e4415dc4b9619e/R/ggplotly.R#L719) in certain conditions, so it should be moved into *imports*.

I have read the development guidelines, and this is such a small commit that do not need new unit tests.


