### PR TITLE
Support Shiny async/promises based rendering

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,8 @@ Imports:
     rlang,
     crosstalk,
     purrr,
-    data.table
+    data.table,
+    promises
 Suggests:
     MASS,
     maps,
@@ -52,7 +53,7 @@ Suggests:
     testthat,
     knitr,
     devtools,
-    shiny (>= 0.14),
+    shiny (>= 1.1.0),
     curl,
     rmarkdown,
     Rserve,

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * The selection (i.e., linked-brushing) mode can now switch from 'transient' to 'persistent' by holding the 'shift' key. It's still possible to _force_ persistent selection by setting `persistent = TRUE` in `highlight()`, but `persistent = FALSE` (the default) is now recommended since it allows one to switch between [persistent/transient selection](https://plotly-book.cpsievert.me/linking-views-without-shiny.html#transient-versus-persistent-selection) in the browser, rather than at the command line.
 * The `highlight()` function gains a `debounce` argument for throttling the rate at which `on` events may be fired. This is mainly useful for improving user experience when `highlight(on = "plotly_hover")` and mousing over relevant markers at a rapid rate (see #1277)
 * The `animation_button()` function gains a `label` argument, making it easier to control the label of an animation button generated through the `frame` API (see #1205).
+* You can now do async rendering of Plotly plots with Shiny, using the [promises](https://rstudio.github.io/promises/) package.
 
 ## CHANGES
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -38,8 +38,17 @@ renderPlotly <- function(expr, env = parent.frame(), quoted = FALSE) {
   if (!quoted) { expr <- substitute(expr) } # force quoted
   # this makes it possible to pass a ggplot2 object to renderPlotly()
   # https://github.com/ramnathv/htmlwidgets/issues/166#issuecomment-153000306
-  expr <- as.call(list(call("::", quote("plotly"), quote("ggplotly")), expr))
+  expr <- as.call(list(call(":::", quote("plotly"), quote("prepareWidget")), expr))
   shinyRenderWidget(expr, plotlyOutput, env, quoted = TRUE)
+}
+
+# Converts a plot, OR a promise of a plot, to plotly
+prepareWidget <- function(x) {
+  if (promises::is.promising(x)) {
+    promises::then(x, ggplotly)
+  } else {
+    ggplotly(x)
+  }
 }
 
 

--- a/inst/examples/shiny/async/app.R
+++ b/inst/examples/shiny/async/app.R
@@ -1,0 +1,42 @@
+library(shiny)
+library(plotly)
+library(ggplot2)
+library(promises)
+library(future)
+plan(multisession)
+
+ui <- fluidPage(
+  plotlyOutput("plot1"),
+  plotlyOutput("plot2"),
+  plotlyOutput("plot3"),
+  plotlyOutput("plot4")
+)
+
+server <- function(input, output, session) {
+  output$plot1 <- renderPlotly({
+    # Async plot_ly
+    future({ Sys.sleep(2); cars }) %...>%
+      plot_ly(x = ~speed, y = ~dist, type = "scatter", mode = "markers")
+  })
+  
+  output$plot2 <- renderPlotly({
+    # Async ggplotly
+    future({ Sys.sleep(2); mtcars }) %...>%
+    { ggplot(., aes(hp, mpg)) + geom_point() } %...>%
+      ggplotly()
+  })
+  
+  output$plot3 <- renderPlotly({
+    # Not async
+    plot_ly(iris, x = ~Sepal.Length, y = ~Sepal.Width,
+            type = "scatter", mode = "markers")
+  })
+  
+  output$plot4 <- renderPlotly({
+    # Ensure errors are handled properly (should be blank)
+    future({}) %...>%
+    { req(FALSE) }
+  })
+}
+
+shinyApp(ui, server)


### PR DESCRIPTION
Example:

```r
library(shiny)
library(plotly)
library(ggplot2)
library(promises)
library(future)
plan(multisession)

ui <- fluidPage(
  plotlyOutput("plot1"),
  plotlyOutput("plot2"),
  plotlyOutput("plot3"),
  plotlyOutput("plot4")
)

server <- function(input, output, session) {
  output$plot1 <- renderPlotly({
    # Async plot_ly
    future({ Sys.sleep(2); cars }) %...>%
      plot_ly(x = ~speed, y = ~dist, type = "scatter", mode = "markers")
  })

  output$plot2 <- renderPlotly({
    # Async ggplotly
    future({ Sys.sleep(2); mtcars }) %...>%
      { ggplot(., aes(hp, mpg)) + geom_point() } %...>%
      ggplotly()
  })
  
  output$plot3 <- renderPlotly({
    # Not async
    plot_ly(iris, x = ~Sepal.Length, y = ~Sepal.Width,
      type = "scatter", mode = "markers")
  })
  
  output$plot4 <- renderPlotly({
    # Ensure errors are handled properly (should be blank)
    future({}) %...>%
      { req(FALSE) }
  })
}

shinyApp(ui, server)
```