### PR TITLE
Changed cursor type of color picker

### DIFF
--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -76,6 +76,7 @@ HTMLWidgets.widget({
         var pickerDiv = document.createElement("div");
         
         var pickerInput = document.createElement("input");
+        pickerInput.style = pickerInput.style + "; cursor: pointer";
         pickerInput.id = el.id + "-colourpicker";
         pickerInput.placeholder = "asdasd";
         


### PR DESCRIPTION
The color picker currently has a text cursor when you hover over it. I've changed this to a `cursor: pointer` style, now it should be more obvious that the color picker object is clickable.