### PR TITLE
Avoid using tempfile() for ID

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -88,7 +88,7 @@ deparse2 <- function(x) {
 }
 
 new_id <- function() {
-  basename(tempfile(""))
+  digest::digest(runif(3), "xxhash64")
 }
 
 names2 <- function(x) {


### PR DESCRIPTION
This changes `new_id()` to use `runif()` and `digest::digest()` to generate reproducible IDs. This is important for testing and resolves https://github.com/rstudio/shinytest/issues/174 and https://github.com/ropensci/plotly/issues/985#issuecomment-367634260.