### PR TITLE
use hoverinfo skip instead of none for invisible ggplotly() colorbar trace, closes #1381

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -1300,7 +1300,7 @@ gdef2trace <- function(gdef, theme, gglayout) {
       type = "scatter",
       mode = "markers",
       opacity = 0,
-      hoverinfo = "none",
+      hoverinfo = "skip",
       showlegend = FALSE,
       # do everything on a 0-1 scale
       marker = list(

--- a/tests/testthat/test-ggplot-sf.R
+++ b/tests/testthat/test-ggplot-sf.R
@@ -54,7 +54,7 @@ test_that("geom_sf() polygons with fill/text.", {
   # one trace for every fillcolor, one for graticule, one for colorbar
   expect_length(l$data, length(unique(nc$AREA)) + 2)
   expect_true(
-    all(unlist(lapply(l$data, "[[", "hoverinfo")) %in% c("none", "text"))
+    all(unlist(lapply(l$data, "[[", "hoverinfo")) %in% c("skip", "none", "text"))
   )
   # graticule styling should inherit from panel.grid.major
   expect_equivalent(


### PR DESCRIPTION
See #1381