### PR TITLE
Properly retain original opacity of 0

### DIFF
--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -522,7 +522,7 @@ function TraceManager(graphDiv, highlight) {
   // avoid doing this over and over
   this.origOpacity = [];
   for (var i = 0; i < this.origData.length; i++) {
-    this.origOpacity[i] = this.origData[i].opacity || 1;
+    this.origOpacity[i] = this.origData[i].opacity === 0 ? 0 : (this.origData[i].opacity || 1);
   }
 
   // key: group name, value: null or array of keys representing the


### PR DESCRIPTION
Closes #1406. 

The bug in #1406 happens because of the hidden trace that is used to render the colorbar. That trace has an opacity of 0, but `0 || 1` evaluates to 1 in JavaScript, so this client-side logic used to store the original opacity (needed for 'clearing' a crosstalk event) was incorrectly storing 1 (instead of 0), making that invisible trace visible when clearing the brush.

## Testing notes

Install (`devtools::install_github("ropensci/plotly#1407")`) then make sure the behavior outlined in #1406 is fixed (i.e. a marker in the lower-left should not appear after click&drag over points and double-clicking to clear the highlight)