### PR TITLE
crosstalk should only delete traces that it has added itself

### DIFF
--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -595,8 +595,8 @@ TraceManager.prototype.updateSelection = function(group, keys) {
   var nNewTraces = this.gd.data.length - this.origData.length;
   if (keys === null || !this.highlight.persistent && nNewTraces > 0) {
     var tracesToRemove = [];
-    for (var i = this.origData.length; i < this.gd.data.length; i++) {
-      tracesToRemove.push(i);
+    for (var i = 0; i < this.gd.data.length; i++) {
+      if (this.gd.data[i]._isCrosstalkTrace) tracesToRemove.push(i);
     }
     Plotly.deleteTraces(this.gd, tracesToRemove);
     this.groupSelections[group] = keys;
@@ -678,6 +678,7 @@ TraceManager.prototype.updateSelection = function(group, keys) {
         // (necessary for updating frames to reflect the selection traces)
         trace._originalIndex = i;
         trace._newIndex = this.gd._fullData.length + traces.length;
+        trace._isCrosstalkTrace = true;
         traces.push(trace);
       }
     }


### PR DESCRIPTION
## Description

Crosstalk highlight events work by adding/deleting traces as needed. Currently, the deleting logic removes _all_ traces added after initial render. This change makes it so only the traces added by crosstalk are removed. 

## Example

In the example below you would expect that a new marker is added to the everytime a point is clicked. Instead, without this change, only a single marker is added (and moves `x` position after every click)

```r
library(plotly)
library(htmlwidgets)

mtcars %>%
  highlight_key() %>%
  plot_ly(x = ~wt, y = ~mpg) %>%
  add_markers() %>%
  highlight("plotly_click") %>%
  onRender("
    function(el) {
      window.nclicks = 0;
      el.on('plotly_click', function(d) {
        window.nclicks = window.nclicks + 1;
        var trace = {
          x: [window.nclicks],
          y: [10],
          type: 'scatter',
          mode: 'markers'
        }
        Plotly.addTraces(el.id, trace);
      })
    }
  ")
```

## Testing Notes

Install `devtools::install_github("ropensci/plotly#1436")` then ensure the example above has the correct behavior
