### PR TITLE
events that don't emit any data should always have event priority, fixes #1466

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -153,10 +153,11 @@ event_data <- function(
     parseJSONVal(session$rootScope()$input[[eventID]])
   }
   
-  priority <- match.arg(priority)
   # events that don't emit any data should _always_ be treated with event priority
-  if (event %in% c("plotly_doubleclick", "plotly_deselect", "plotly_afterplot")) {
-    priority <- "event"
+  priority <- if (event %in% c("plotly_doubleclick", "plotly_deselect", "plotly_afterplot")) {
+    "event"
+  } else {
+    match.arg(priority)
   }
   
   if (priority == "event") {

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -154,6 +154,11 @@ event_data <- function(
   }
   
   priority <- match.arg(priority)
+  # events that don't emit any data should _always_ be treated with event priority
+  if (event %in% c("plotly_doubleclick", "plotly_deselect", "plotly_afterplot")) {
+    priority <- "event"
+  }
+  
   if (priority == "event") {
     # Shiny.setInputValue() is always called with event priority
     # so simply return the parse input value


### PR DESCRIPTION
See #1466