### PR TITLE
sec_axis support

### DIFF
--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -98,6 +98,12 @@ layers2traces <- function(data, prestats_data, layout, p) {
   trace.list <- list()
   for (i in seq_along(datz)) {
     d <- datz[[i]]
+    secondary_flag = ''
+    if('axis' %in% names(d)){
+      if(d$axis[1]==2){
+        secondary_flag ='2'  
+      }
+    }
     # variables that produce multiple traces and deserve their own legend entries
     split_legend <- paste0(names(discreteScales), "_plotlyDomain")
     # add variable that produce multiple traces, but do _not_ deserve entries
@@ -141,7 +147,7 @@ layers2traces <- function(data, prestats_data, layout, p) {
     for (j in seq_along(trs)) {
       panel <- unique(dl[[j]]$PANEL)
       trs[[j]]$xaxis <-  sub("axis", "", layout$layout[panel, "xaxis"])
-      trs[[j]]$yaxis <-  sub("axis", "", layout$layout[panel, "yaxis"])
+      trs[[j]]$yaxis <-  paste0(sub("axis", "", layout$layout[panel, "yaxis"]),secondary_flag)
     }
     trace.list <- c(trace.list, trs)
   }

--- a/tests/testthat/test-ggplot-sec_axis.R
+++ b/tests/testthat/test-ggplot-sec_axis.R
@@ -1,0 +1,25 @@
+context("ggplot sec_axis")
+
+test_that("Yaxis2 in layout", {
+  p = ggplotly(ggplot(mtcars,aes(x=drat,y=hp))+geom_point()+
+    geom_point(aes(y=qsec,color='red',axis='sec'))+
+    scale_y_continuous(sec.axis = sec_axis(~./6,'2nd Axis')))
+
+  expect_identical(TRUE,'yaxis2' %in% names(p$x$layout))
+})
+
+test_that("Yaxis2 labelled correctly", {
+  p = ggplotly(ggplot(mtcars,aes(x=drat,y=hp))+geom_point()+
+    geom_point(aes(y=qsec,color='red',axis='sec'))+
+    scale_y_continuous(sec.axis = sec_axis(~./6,'2nd Axis')))
+    
+  expect_identical('2nd Axis',p$x$layout$yaxis2$title)
+})
+
+test_that("Second trace attributed to y2", {
+  p = ggplotly(ggplot(mtcars,aes(x=drat,y=hp))+geom_point()+
+                 geom_point(aes(y=qsec,color='red',axis='sec'))+
+                 scale_y_continuous(sec.axis = sec_axis(~./6,'2nd Axis')))
+  
+  expect_identical('y2',p$x$data[[2]]$yaxis)
+})


### PR DESCRIPTION
```
ggplotly(ggplot(mtcars,aes(x=drat,y=hp))+geom_point()+
  geom_point(aes(y=qsec,color='red',axis=2))+
  scale_y_continuous(sec.axis = sec_axis(~./6,'2nd Axis')))
```

an additional `axis='sec'` or  `axis=2` is necessary in the geom for ggplotly to know which trace needs to be mapped onto y2, which results in a warning from ggplot (`Ignoring unknown aesthetics: axis`) but the outcome seems good enough to me. let me know what you think (tests included).
