### PR TITLE
Fixes for ggplot2 >3.1.0

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -236,10 +236,18 @@ gg2list <- function(p, width = NULL, height = NULL,
     out
   }
   
+  # ggplot2 3.1.0.9000 introduced a Layer method named setup_layer() 
+  # currently, LayerSf is the only core-ggplot2 Layer that makes use
+  # of it https://github.com/tidyverse/ggplot2/pull/2875
+  data <- layer_data
+  if (packageVersion("ggplot2") > "3.1.0") {
+    data <- by_layer(function(l, d) l$setup_layer(d, plot))
+  }
+  
   # Initialise panels, add extra data for margins & missing facetting
   # variables, and add on a PANEL variable to data
   layout <- ggfun("create_layout")(plot$facet, plot$coordinates)
-  data <- layout$setup(layer_data, plot$data, plot$plot_env)
+  data <- layout$setup(data, plot$data, plot$plot_env)
   
   # save the domain of the group for display in tooltips
   groupDomains <- Map(function(x, y) {

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -999,8 +999,13 @@ aes2plotly <- function(data, params, aes = "size") {
   defaults <- if (inherits(data, "GeomSf")) {
     type <- if (any(grepl("point", class(data)))) "point" else if (any(grepl("line", class(data)))) "line" else ""
     ggfun("default_aesthetics")(type)
-  } else if ("default_aes" %in% names(ggfun(geom))) {
-    ggfun(geom)$default_aes
+  } else {
+    geom_obj <- ggfun(geom)
+    # If the first class of `data` is a data.frame,
+    # ggfun() returns a function because ggplot2 now
+    # defines data.frame in it's namespace
+    # https://github.com/ropensci/plotly/pull/1481
+    if ("default_aes" %in% names(geom_obj)) geom_obj$default_aes else NULL
   }
   
   vals <- uniq(data[[aes]]) %||% params[[aes]] %||% defaults[[aes]] %||% NA

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -999,7 +999,7 @@ aes2plotly <- function(data, params, aes = "size") {
   defaults <- if (inherits(data, "GeomSf")) {
     type <- if (any(grepl("point", class(data)))) "point" else if (any(grepl("line", class(data)))) "line" else ""
     ggfun("default_aesthetics")(type)
-  } else {
+  } else if ("default_aes" %in% names(ggfun(geom))) {
     ggfun(geom)$default_aes
   }
   


### PR DESCRIPTION
Closes #1457.

This was a fun 🐛 to track down 🔍 

## Background

Typically, when `ggplotly()` translates a layer, it prefixes the class of the data with `"Geom*"`. This is what allows `geom2plotly()` to work off S3 methods. The `aes2plotly()` function also uses this class to query the Geom's default aesthetics from ggplot2's namespace. 

## The issue

To translate the graticule that comes with `geom_sf()`/`coord_sf()`, I call `geom2trace.GeomPath()` in a fairly un-standard way:

https://github.com/ropensci/plotly/blob/4473d6454f01825e8f15783e670e6fffb017e123/R/ggplotly.R#L611

That ends up calling this code, and in this case, the value of `geom` is `data.frame`. 

https://github.com/ropensci/plotly/blob/4473d6454f01825e8f15783e670e6fffb017e123/R/layers2traces.R#L1003

As of https://github.com/tidyverse/ggplot2/commit/92d27779e210ce16f441eeec26926b8b045a47a8, **ggplot2** now defines `data.frame` in it's namespace, so `ggfun(geom)$default_aes` no longer returns `NULL` (in fact, it errors out)


