### PR TITLE
subplot(): fix ystart/yend double flip

### DIFF
--- a/R/subplots.R
+++ b/R/subplots.R
@@ -237,7 +237,7 @@ subplot <- function(..., nrows = 1, widths = NULL, heights = NULL, margin = 0.02
     
     # rescale domains according to the tabular layout
     xDom <- as.numeric(domainInfo[i, c("xstart", "xend")])
-    yDom <- as.numeric(domainInfo[i, c("yend", "ystart")])
+    yDom <- as.numeric(domainInfo[i, c("ystart", "yend")])
     reScale <- function(old, new) {
       sort(scales::rescale(
         old %||% c(0, 1), new, from = c(0, 1)
@@ -390,8 +390,8 @@ get_domains <- function(nplots = 1, nrows = 1, margins = 0.01,
   for (i in seq_len(nplots)) {
     j <- ceiling(i / ncols)
     ys[[i]] <- c(
-      ystart = 1 - (heights[j]) - if (j == 1) 0 else margins[3],
-      yend = 1 - (heights[j + 1]) + if (j == nrows) 0 else margins[4]
+      ystart = 1 - (heights[j + 1]) + if (j == nrows) 0 else margins[4],
+      yend = 1 - (heights[j]) - if (j == 1) 0 else margins[3]
     )
   }
   list2df(Map(c, xz, ys))
@@ -410,7 +410,7 @@ list2df <- function(x, nms) {
 reposition <- function(obj, domains) {
   # we need x and y in order to rescale them!
   xdom <- as.numeric(domains[c("xstart", "xend")])
-  ydom <- as.numeric(domains[c("yend", "ystart")])
+  ydom <- as.numeric(domains[c("ystart", "yend")])
   
   for (i in seq_along(obj)) {
     o <- obj[[i]]


### PR DESCRIPTION
This is a small cleanup to the `subplot()` grid layout logic: when defining the new domains of Y axis, `get_domains()` sets the new `ystart` > `yend`, but later in `subplot()`/`reposition()` the `ystart` and `yend` are reversed to do the proper transformation.
With the fix the logic of handling both X and Y axes is unified: **start* is always less than **end*, the axis domain is always from **start* to **end*.