### PR TITLE
geom_boxplot() improvements

### DIFF
--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -786,6 +786,8 @@ geom2trace.GeomBoxplot <- function(data, params, p) {
     frame = data[["frame"]],
     ids = data[["ids"]],
     type = "box",
+    notched = params[["notch"]],
+    notchwidth = params[["notchwidth"]],
     fillcolor = toRGB(
       aes2plotly(data, params, "fill"),
       aes2plotly(data, params, "alpha")


### PR DESCRIPTION
This changes the default behaivor of ggplotly() to render `geom_boxplot()` as low-level polygons rather than the plotly.js trace type. As result, we'll be able to exactly replicate the ggplot2 result in many more cases. A list of relevant issues this PR should close: #1484, #1241, #1114, #1098, #866, #697, #706

TODO:

- [ ] Should we still support translation of `geom_boxplot()` to plotly.js box traces? If so, how?