### PR TITLE
Wrap user-supplied expression in evalq(), closes #1528

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -67,13 +67,14 @@ renderPlotly <- function(expr, env = parent.frame(), quoted = FALSE) {
 
 # Converts a plot, OR a promise of a plot, to plotly
 prepareWidget <- function(x) {
-  p <- if (promises::is.promising(x)) {
-    promises::then(x, plotly_build)
+  if (promises::is.promising(x)) {
+    promises::then(
+      promises::then(x, plotly_build),
+      register_plot_events
+    )
   } else {
-    plotly_build(x)
+    register_plot_events(plotly_build(x))
   }
-  register_plot_events(p)
-  p
 }
 
 register_plot_events <- function(p) {
@@ -83,6 +84,7 @@ register_plot_events <- function(p) {
     session$userData$plotlyShinyEventIDs,
     eventIDs
   ))
+  p
 }
 
 


### PR DESCRIPTION
## Background

In order to render promises (that yield plotly objects), ggplot2 objects, and orchestrate event registration, `renderPlotly()` wraps user-supplied (reactive) expressions with `plotly:::prepareWidget()`

## The problem

If a user-supplied expression contains a `return()` statement. It appears `plotly:::prepareWidget()` will exit early. For an example, see below in the testing notes and/or the example in #1528

## Testing notes

Install `devtools::install_github("ropensci/plotly")`, then run the app:

```r
library(shiny)
library(plotly)

ui <- fluidPage(
  plotlyOutput("myplot"),
  verbatimTextOutput("hovered")
)

server <- function(input, output, session) {
  
  x <- faithful$eruptions
  y <- faithful$waiting
  
  output$myplot <- renderPlotly({
    p <- plot_ly(x = x, y = y) %>%
      add_markers()
    return(p)
  })
  
  output$hovered <- renderPrint({
    event_data("plotly_hover")
  })
  
}

shinyApp(ui = ui, server = server)
```

* __Old behavior__: The app would throw multiple (irrelevant) warnings.

*  __New behavior__: The app should throw no warnings.

