### PR TITLE
Better resizing logic

### DIFF
--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -17,6 +17,12 @@ HTMLWidgets.widget({
   
   renderValue: function(el, x, instance) {
     
+    // Make a deep copy of user data that we need for the resize method 
+    // (Plotly.relayout() mutates the plot input object -- https://codepen.io/cpsievert/pen/WNeOrjj) 
+    instance.width = JSON.parse(JSON.stringify(x.layout.width || null));
+    instance.height = JSON.parse(JSON.stringify(x.layout.height || null));
+    instance.autosize = JSON.parse(JSON.stringify(x.layout.autosize || true));
+    
     /* 
     / 'inform the world' about highlighting options this is so other
     / crosstalk libraries have a chance to respond to special settings 
@@ -153,16 +159,8 @@ HTMLWidgets.widget({
       
       var plot = Plotly.plot(graphDiv, x);
       instance.plotly = true;
-      instance.autosize = x.layout.autosize || true;
-      instance.width = x.layout.width;
-      instance.height = x.layout.height;
       
     } else {
-      
-      // new x data could contain a new height/width...
-      // attach to instance so that resize logic knows about the new size
-      instance.width = x.layout.width || instance.width;
-      instance.height = x.layout.height || instance.height;
       
       // this is essentially equivalent to Plotly.newPlot(), but avoids creating 
       // a new webgl context

--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -17,11 +17,13 @@ HTMLWidgets.widget({
   
   renderValue: function(el, x, instance) {
     
-    // Make a deep copy of user data that we need for the resize method 
-    // (Plotly.relayout() mutates the plot input object -- https://codepen.io/cpsievert/pen/WNeOrjj) 
-    instance.width = JSON.parse(JSON.stringify(x.layout.width || null));
-    instance.height = JSON.parse(JSON.stringify(x.layout.height || null));
-    instance.autosize = JSON.parse(JSON.stringify(x.layout.autosize || true));
+    // Plotly.relayout() mutates the plot input object, so make sure to 
+    // keep a reference to the user-supplied width/height *before*
+    // we call Plotly.plot();
+    var lay = x.layout || {};
+    instance.width = lay.width;
+    instance.height = lay.height;
+    instance.autosize = lay.autosize || true;
     
     /* 
     / 'inform the world' about highlighting options this is so other


### PR DESCRIPTION
@jcheng5 I dug deeper into the root issue behind #1553. It turns out that `Plotly.relayout()` mutates input to `Plotly.plot()` ([minimal example](https://codepen.io/cpsievert/pen/WNeOrjj)). Normally this doesn't pose a problem for resizing logic, but for that dynamic UI example, `renderValue` gets called twice for every widget (meaning `x.layout.width`, and `instance.width` is populated during the second render).

Anyway, after this discovery, I think it's safer to make a deep copy of `width`/`height`/`autosize` at the start of `renderValue` (instead of using attributes attached to the DOM element)