### PR TITLE
Wrapping of user-supplied expressions in renderPlotly

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -48,10 +48,9 @@ renderPlotly <- function(expr, env = parent.frame(), quoted = FALSE) {
   # prepareWidget() makes it possible to pass different non-plotly
   # objects to renderPlotly() (e.g., ggplot2, promises). It also is used 
   # to inform event_data about what events have been registered
-  shiny::installExprFunction(expr, "func", env, quoted)
-  renderFunc <- shinyRenderWidget(
-    plotly:::prepareWidget(func()), plotlyOutput, env, quoted
-  )
+  shiny::installExprFunction(expr, "func", env, quoted, assign.env = env)
+  expr <- quote(plotly:::prepareWidget(func()))
+  renderFunc <- shinyRenderWidget(expr, plotlyOutput, env, quoted)
   # remove 'internal' plotly attributes that are known to cause false
   # positive test results in shinytest (snapshotPreprocessOutput was added 
   # in shiny 1.0.3.9002, but we require >= 1.1)

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -37,11 +37,21 @@ plotlyOutput <- function(outputId, width = "100%", height = "400px",
 #' @rdname plotly-shiny
 #' @export
 renderPlotly <- function(expr, env = parent.frame(), quoted = FALSE) {
-  if (!quoted) { expr <- substitute(expr) } # force quoted
-  # this makes it possible to pass a ggplot2 object to renderPlotly()
-  # https://github.com/ramnathv/htmlwidgets/issues/166#issuecomment-153000306
-  expr <- as.call(list(call(":::", quote("plotly"), quote("prepareWidget")), expr))
-  renderFunc <- shinyRenderWidget(expr, plotlyOutput, env, quoted = TRUE)
+  if (!quoted) { 
+    quoted <- TRUE
+    expr <- substitute(expr) 
+  }
+  # Install the (user-supplied) expression as a function
+  # This way, if the user-supplied expression contains a return()
+  # statement, we can capture that return value and pass it along
+  # to prepareWidget()
+  # prepareWidget() makes it possible to pass different non-plotly
+  # objects to renderPlotly() (e.g., ggplot2, promises). It also is used 
+  # to inform event_data about what events have been registered
+  shiny::installExprFunction(expr, "func", env, quoted)
+  renderFunc <- shinyRenderWidget(
+    plotly:::prepareWidget(func()), plotlyOutput, env, quoted
+  )
   # remove 'internal' plotly attributes that are known to cause false
   # positive test results in shinytest (snapshotPreprocessOutput was added 
   # in shiny 1.0.3.9002, but we require >= 1.1)
@@ -57,13 +67,14 @@ renderPlotly <- function(expr, env = parent.frame(), quoted = FALSE) {
 
 # Converts a plot, OR a promise of a plot, to plotly
 prepareWidget <- function(x) {
-  p <- if (promises::is.promising(x)) {
-    promises::then(x, ggplotly)
+  if (promises::is.promising(x)) {
+    promises::then(
+      promises::then(x, ggplotly),
+      register_plot_events
+    )
   } else {
-    ggplotly(x)
+    register_plot_events(ggplotly(x))
   }
-  register_plot_events(p)
-  p
 }
 
 register_plot_events <- function(p) {
@@ -73,6 +84,7 @@ register_plot_events <- function(p) {
     session$userData$plotlyShinyEventIDs,
     eventIDs
   ))
+  p
 }
 
 


### PR DESCRIPTION
Another attempt at #1539, which was merged before fully understanding the shinytest failure (my bad). Note that the merge commit was already reverted on master via https://github.com/ropensci/plotly/commit/285673153adc56ec0cbb8a01d0af4c46f3894b00

I had tested #1539 on some minimal apps, but it turns out it would fail on any `renderPlotly()` statement that contained a reactive read. For example:

```r
library(shiny)
library(plotly)

ui <- fluidPage(
  selectInput("x", "X", names(diamonds)),
  plotlyOutput("p")
)

server <- function(input, output, session) {
  output$p <- renderPlotly({
    plot_ly(x = 1, y = 1, text = input$x)
  })
}
shinyApp(ui, server)
```

```r
Error in .getReactiveEnvironment()$currentContext: Operation not allowed without an active reactive context. (You tried to do something that can only be done from inside a reactive expression or observer.)
  71: stop
  70: .getReactiveEnvironment()$currentContext [/Users/cpsievert/github/shiny/R/react.R#143]
  69: getCurrentContext [/Users/cpsievert/github/shiny/R/react.R#202]
  65: .subset2(x, "impl")$get [/Users/cpsievert/github/shiny/R/reactives.R#344]
  64: $.reactivevalues [/Users/cpsievert/github/shiny/R/reactives.R#605]
  61: renderPlotly [#4]
  60: func
  53: renderPlotly [/Users/cpsievert/github/plotly/R/shiny.R#52]
  52: server [#3]
Error in .getReactiveEnvironment()$currentContext() : 
  Operation not allowed without an active reactive context. (You tried to do something that can only be done from inside a reactive expression or observer.)
```


I believe the problem is due to `prepareWidget(func())` being evaluated too early? 1a714b8 addresses the problem by passing this in as a quoted expression.