### PR TITLE
Improvements to algorithm for attaching key attribute for shiny's event data, fixes #1610

### DIFF
--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -263,10 +263,13 @@ HTMLWidgets.widget({
         for (var i = 0; i < attrsToAttach.length; i++) {
           var attr = trace[attrsToAttach[i]];
           if (Array.isArray(attr)) {
-              // pointNumber can be an array (e.g., heatmaps)
-              // TODO: can pointNumber be 3D?
-              obj[attrsToAttach[i]] = typeof pt.pointNumber === "number" ? 
-                attr[pt.pointNumber] : attr[pt.pointNumber[0]][pt.pointNumber[1]];
+            var ptNums = pt.pointNumber || pt.pointNumbers;
+            if (typeof ptNums === "number") {
+              ptNums = [ptNums];
+            }
+            if (Array.isArray(ptNums)) {
+              obj[attrsToAttach[i]] = ptNums.map(function(i) { return attr[i]; });
+            }
           }
         }
         return obj;

--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -263,11 +263,12 @@ HTMLWidgets.widget({
         for (var i = 0; i < attrsToAttach.length; i++) {
           var attr = trace[attrsToAttach[i]];
           if (Array.isArray(attr)) {
-            var ptNums = pt.pointNumber || pt.pointNumbers;
-            if (typeof ptNums === "number") {
-              obj[attrsToAttach[i]] = ptNums;
-            } else if (Array.isArray(ptNums)) {
-              obj[attrsToAttach[i]] = ptNums.map(function(i) { return attr[i]; });
+            if (typeof pt.pointNumber === "number") {
+              obj[attrsToAttach[i]] = attr[pt.pointNumber];
+            } else if (Array.isArray(pt.pointNumber)) {
+              obj[attrsToAttach[i]] = attr[pt.pointNumber[0]][pt.pointNumber[1]];
+            } else if (Array.isArray(pt.pointNumbers)) {
+              obj[attrsToAttach[i]] = pt.pointNumbers.map(function(i) { return attr[i]; });
             }
           }
         }

--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -268,7 +268,7 @@ HTMLWidgets.widget({
             } else if (Array.isArray(pt.pointNumber)) {
               obj[attrsToAttach[i]] = attr[pt.pointNumber[0]][pt.pointNumber[1]];
             } else if (Array.isArray(pt.pointNumbers)) {
-              obj[attrsToAttach[i]] = pt.pointNumbers.map(function(i) { return attr[i]; });
+              obj[attrsToAttach[i]] = pt.pointNumbers.map(function(idx) { return attr[idx]; });
             }
           }
         }

--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -265,9 +265,8 @@ HTMLWidgets.widget({
           if (Array.isArray(attr)) {
             var ptNums = pt.pointNumber || pt.pointNumbers;
             if (typeof ptNums === "number") {
-              ptNums = [ptNums];
-            }
-            if (Array.isArray(ptNums)) {
+              obj[attrsToAttach[i]] = ptNums;
+            } else if (Array.isArray(ptNums)) {
               obj[attrsToAttach[i]] = ptNums.map(function(i) { return attr[i]; });
             }
           }


### PR DESCRIPTION
Fixes #1610. Note also that when `pt.pointNumbers` is populated, the `key` attribute is relayed properly

## Testing notes

Install `remotes::install_github("ropensci/plotly")`, then run the app below. As you hover over points, information about the hovered point should appear in the R console.

```r
library(shiny)
library(plotly)

ui <- fluidPage(
  plotlyOutput("distPlotTest")
)

server <- function(input, output) {
  
  output$distPlotTest <- renderPlotly({
    highlight_key(mtcars, ~carb) %>%
      plot_ly(x = ~mtcars$carb, key = ~row.names(mtcars), type = "histogram") %>%
        layout(barmode = "overlay") %>% 
        highlight(on = "plotly_hover", off="plotly_deselect") 
  })
  
  observe({
    print(event_data("plotly_hover"))
  })
  
}

# Run the application
shinyApp(ui = ui, server = server)
```