### PR TITLE
alter new_id() so the id depends on set.seed()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -93,7 +93,7 @@ deparse2 <- function(x) {
 }
 
 new_id <- function() {
-  basename(tempfile(""))
+  paste(sample(c(0:9, letters), 12, replace = TRUE), collapse = "")
 }
 
 names2 <- function(x) {


### PR DESCRIPTION
The current implementation is not affected by `set.seed()`. Rerunning the same code results in different id's, even if `set.seed()` is set.

The new version is based on `sample()`, yielding stable ids in case the user sets `set.seed()`. The benefit is that rerunning the code with unchanged definition and data yields identical HTML code. This is useful when the output is stored under version control.