### PR TITLE
Ignore calculated aesthetics that match specified aesthestics

### DIFF
--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -10,12 +10,14 @@ layers2traces <- function(data, prestats_data, layout, p) {
       position = ggtype(y, "position")
     )
     
+    # add on plot-level mappings, if they're inherited
+    map <- c(y$mapping, if (isTRUE(y$inherit.aes)) p$mapping)
+    
     # consider "calculated" aesthetics (e.g., density, count, etc)
     calc_aes <- y$stat$default_aes[ggfun("is_calculated_aes")(y$stat$default_aes)]
-    map <- c(y$mapping, calc_aes)
+    calc_aes <- calc_aes[!names(calc_aes) %in% names(map)]
     
-    # add on plot-level mappings, if they're inherited
-    if (isTRUE(y$inherit.aes)) map <- c(map, p$mapping)
+    map <- c(calc_aes, map)
     
     # turn symbol (e.g., ..count..) & call (e.g. calc(count)) mappings into text labels 
     map <- ggfun("make_labels")(map)


### PR DESCRIPTION
After https://github.com/tidyverse/ggplot2/commit/10fa0014, it's now possible for calculated aes to exist for all default_aes...27db11e278ce92bef7ec9a4c8be5ee3b3078c9e1 just removes any "calculated aes" that are also a "user-specified aes" from consideration when building the tooltip

27db11e278ce92bef7ec9a4c8be5ee3b3078c9e1 also changes the ordering in which the aes appear in the tooltip from:

* Layer aes
* Calculated aes
* Global aes

to what I think is a better default:

* Calculated aes
* Layer aes
* Global aes


## Testing notes

Confirm that density appears once (not twice) in the tooltip when hovering on the density lines:

```r
library(plotly)

p <- ggplot(mtcars, aes(x = mpg, fill = factor(cyl))) + 
  geom_density()
ggplotly(p)
```

