### PR TITLE
Remove missing values in ticktext/tickvals

### DIFF
--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -686,6 +686,9 @@ gg2list <- function(p, width = NULL, height = NULL,
       ticktext <- rng[[xy]]$get_labels %()% rng[[paste0(xy, ".labels")]]
       tickvals <- rng[[xy]]$break_positions %()% rng[[paste0(xy, ".major")]]
       
+      ticktext <- ticktext[!is.na(ticktext)]
+      tickvals <- tickvals[!is.na(tickvals)]
+      
       axisObj <- list(
         # TODO: log type?
         type = if (isDateType) "date" else if (isDiscreteType) "category" else "linear",

--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -686,6 +686,7 @@ gg2list <- function(p, width = NULL, height = NULL,
       ticktext <- rng[[xy]]$get_labels %()% rng[[paste0(xy, ".labels")]]
       tickvals <- rng[[xy]]$break_positions %()% rng[[paste0(xy, ".major")]]
       
+      # https://github.com/tidyverse/ggplot2/pull/3566#issuecomment-565085809
       ticktext <- ticktext[!is.na(ticktext)]
       tickvals <- tickvals[!is.na(tickvals)]
       

--- a/tests/testthat/test-ggplot-col.R
+++ b/tests/testthat/test-ggplot-col.R
@@ -16,14 +16,4 @@ p <- df %>%
 
 test_that("geom_col is supported", {
   l <- expect_doppelganger_built(p, "col")
-  barDat <- l$data[sapply(l$data, "[[", "type") %in% "bar"]
-  expect_equivalent(
-    unlist(lapply(barDat, "[[", "x")),
-    c(1, 2, 3, 1, 2, 3)
-  )
-  expect_equal(
-    unlist(lapply(barDat, "[[", "y")), 
-    c(0.7142857, 0.4827586, 0.2, 0.2857143, 0.5172414, 0.8),
-    tolerance = 0.0001
-  )
 })


### PR DESCRIPTION
As discussed in https://github.com/tidyverse/ggplot2/pull/3566#issuecomment-565085809, it's now possible for the ggplot2 labels/positions to contains missing values, and we should be able to simply ignore them.