### PR TITLE
Fix axis facets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 ## BUG FIXES
 
+* `ggplotly()` now handles discrete axes of a `facet_wrap` and `facet_grid` correctly when there is only one category in panels > 1 (#1577 and #1720).
+
 * `ggplotly()` now handles `element_blank()` and `factor()` labels in positional scales correctly (#1731 and #1772).
 
 # 4.9.2.1

--- a/R/utils.R
+++ b/R/utils.R
@@ -521,7 +521,7 @@ verify_attr <- function(proposed, schema, layoutAttr = FALSE) {
     
     # do the same for "sub-attributes"
     if (identical(role, "object") && is.recursive(proposed[[attr]])) {
-      proposed[[attr]] <- verify_attr(proposed[[attr]], schema[[attr]], layoutAttr = layoutAttr)
+      proposed[[attr]] <- verify_attr(proposed[[attr]], attrSchema, layoutAttr = layoutAttr)
     }
   }
   

--- a/tests/testthat/test-facet-axis.R
+++ b/tests/testthat/test-facet-axis.R
@@ -1,0 +1,11 @@
+test_that("ggplotly does not break discrete x-axis with facet_yyyy in panels > 1 with only one category", {
+  d <- data.frame(cat = c("A", "A", "A"), pan = paste("Panel", c(1, 2, 2)))
+  gp <- ggplot(d, aes(cat)) +
+    geom_bar() +
+    facet_wrap(~pan)
+  L <- plotly_build(ggplotly(gp))
+  # tickvals, ticktext and categoryarray have class 'AsIs'
+  expect_equal(class(L$x$layout$xaxis2$tickvals), "AsIs")
+  expect_equal(class(L$x$layout$xaxis2$ticktext), "AsIs")
+  expect_equal(class(L$x$layout$xaxis2$categoryarray), "AsIs")
+})

--- a/tests/testthat/test-facet-axis.R
+++ b/tests/testthat/test-facet-axis.R
@@ -5,7 +5,11 @@ test_that("ggplotly does not break discrete x-axis with facet_yyyy in panels > 1
     facet_wrap(~pan)
   L <- plotly_build(ggplotly(gp))
   # tickvals, ticktext and categoryarray have class 'AsIs'
-  expect_equal(class(L$x$layout$xaxis2$tickvals), "AsIs")
-  expect_equal(class(L$x$layout$xaxis2$ticktext), "AsIs")
-  expect_equal(class(L$x$layout$xaxis2$categoryarray), "AsIs")
+  lapply(L$x$layout[c("xaxis", "xaxis2")], function(axis) {
+    expect_s3_class(axis$tickvals, "AsIs")
+    expect_s3_class(axis$ticktext, "AsIs")
+    expect_true(axis$ticktext == "A")
+    expect_s3_class(axis$categoryarray, "AsIs")
+    expect_true(axis$categoryarray == "A")
+  })
 })


### PR DESCRIPTION
This PR fixes a bug in `verify_attr` which closes #1720 and #1577 .

Adding the fix the reprex from #1720 is rendered like so

![grafik](https://user-images.githubusercontent.com/16198114/83979967-56dc3900-a912-11ea-8c31-e91ff0da5e19.png)

and the reprex from #1577 like so:

![grafik](https://user-images.githubusercontent.com/16198114/83979984-72dfda80-a912-11ea-861b-a723ac3f5eb1.png)
