### PR TITLE
Update dplyr functions to use non-standard evaluation

### DIFF
--- a/R/add.R
+++ b/R/add.R
@@ -334,7 +334,7 @@ add_sf <- function(p, ..., x = ~x, y = ~y, data = NULL, inherit = TRUE) {
       y = y,
       `_bbox` = bbox,
       set = set,
-      data = if ("group" %in% names(d[[i]])) group_by_(d[[i]], "group", add = TRUE) else d[[i]], 
+      data = if ("group" %in% names(d[[i]])) group_by(d[[i]], rlang::sym("group"), .add = TRUE) else d[[i]], 
       inherit = inherit
     )
     args <- modify_list(args, attrs)

--- a/R/add.R
+++ b/R/add.R
@@ -334,7 +334,7 @@ add_sf <- function(p, ..., x = ~x, y = ~y, data = NULL, inherit = TRUE) {
       y = y,
       `_bbox` = bbox,
       set = set,
-      data = if ("group" %in% names(d[[i]])) group_by_add(d[[i]], !!rlang::sym("group"), add = TRUE) else d[[i]], 
+      data = if ("group" %in% names(d[[i]])) group_by_add(d[[i]], !!rlang::sym("group")) else d[[i]], 
       inherit = inherit
     )
     args <- modify_list(args, attrs)

--- a/R/add.R
+++ b/R/add.R
@@ -334,7 +334,7 @@ add_sf <- function(p, ..., x = ~x, y = ~y, data = NULL, inherit = TRUE) {
       y = y,
       `_bbox` = bbox,
       set = set,
-      data = if ("group" %in% names(d[[i]])) group_by(d[[i]], !!rlang::sym("group"), .add = TRUE) else d[[i]], 
+      data = if ("group" %in% names(d[[i]])) group_by_add(d[[i]], !!rlang::sym("group"), add = TRUE) else d[[i]], 
       inherit = inherit
     )
     args <- modify_list(args, attrs)

--- a/R/add.R
+++ b/R/add.R
@@ -334,7 +334,7 @@ add_sf <- function(p, ..., x = ~x, y = ~y, data = NULL, inherit = TRUE) {
       y = y,
       `_bbox` = bbox,
       set = set,
-      data = if ("group" %in% names(d[[i]])) group_by(d[[i]], rlang::sym("group"), .add = TRUE) else d[[i]], 
+      data = if ("group" %in% names(d[[i]])) group_by(d[[i]], !!rlang::sym("group"), .add = TRUE) else d[[i]], 
       inherit = inherit
     )
     args <- modify_list(args, attrs)

--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -495,7 +495,7 @@ gg2list <- function(p, width = NULL, height = NULL,
       )
     }
     # anchor X axis to the lowest plot in its column
-    layout$layout <- dplyr::group_by_(layout$layout, "xaxis")
+    layout$layout <- dplyr::group_by(layout$layout, !!rlang::sym("xaxis"))
     layout$layout <-  dplyr::mutate(layout$layout, xanchor = max(as.integer(yaxis)))
   }
   layout$layout <- as.data.frame(layout$layout)
@@ -1088,7 +1088,7 @@ gg2list <- function(p, width = NULL, height = NULL,
   # translate group aesthetics to data attributes
   return_dat <- Map(function(x, y) {
     if (is.null(y[["group"]])) return(x)
-    dplyr::group_by_(x, y[["group"]])
+    dplyr::group_by(x, !!rlang::as_quosure(y[["group"]]))
   }, return_dat, mappingFormulas)
   
   # don't need to add group as an attribute anymore

--- a/R/imports.R
+++ b/R/imports.R
@@ -24,11 +24,23 @@ NULL
 #' @export
 dplyr::mutate
 
+#' @importFrom dplyr mutate_
+#' @name mutate_
+#' @rdname reexports
+#' @export
+dplyr::mutate_
+
 #' @importFrom dplyr transmute
 #' @name transmute
 #' @rdname reexports
 #' @export
 dplyr::transmute
+
+#' @importFrom dplyr transmute_
+#' @name transmute_
+#' @rdname reexports
+#' @export
+dplyr::transmute_
 
 #' @importFrom dplyr select
 #' @name select
@@ -36,17 +48,35 @@ dplyr::transmute
 #' @export
 dplyr::select
 
+#' @importFrom dplyr select_
+#' @name select_
+#' @rdname reexports
+#' @export
+dplyr::select_
+
 #' @importFrom dplyr rename
 #' @name rename
 #' @rdname reexports
 #' @export
 dplyr::rename
 
+#' @importFrom dplyr rename_
+#' @name rename_
+#' @rdname reexports
+#' @export
+dplyr::rename_
+
 #' @importFrom dplyr group_by 
 #' @name group_by
 #' @rdname reexports
 #' @export
 dplyr::group_by
+
+#' @importFrom dplyr group_by_
+#' @name group_by_
+#' @rdname reexports
+#' @export
+dplyr::group_by_
 
 #' @importFrom dplyr groups
 #' @name groups
@@ -66,22 +96,47 @@ dplyr::ungroup
 #' @export
 dplyr::summarise
 
+#' @importFrom dplyr summarise_
+#' @name summarise_
+#' @rdname reexports
+#' @export
+dplyr::summarise_
+
 #' @importFrom dplyr do
 #' @name do
 #' @rdname reexports
 #' @export
 dplyr::do
 
+#' @importFrom dplyr do_
+#' @name do_
+#' @rdname reexports
+#' @export
+dplyr::do_
+
 #' @importFrom dplyr arrange
 #' @name arrange
 #' @rdname reexports
 #' @export
 dplyr::arrange
+
+#' @importFrom dplyr arrange_
+#' @name arrange_
+#' @rdname reexports
+#' @export
+dplyr::arrange_
+
 #' @importFrom dplyr distinct
 #' @name distinct
 #' @rdname reexports
 #' @export
 dplyr::distinct
+
+#' @importFrom dplyr distinct_
+#' @name distinct_
+#' @rdname reexports
+#' @export
+dplyr::distinct_
 
 #' @importFrom dplyr slice
 #' @name slice
@@ -89,11 +144,23 @@ dplyr::distinct
 #' @export
 dplyr::slice
 
+#' @importFrom dplyr slice_
+#' @name slice_
+#' @rdname reexports
+#' @export
+dplyr::slice_
+
 #' @importFrom dplyr filter
 #' @name filter
 #' @rdname reexports
 #' @export
 dplyr::filter
+
+#' @importFrom dplyr filter_
+#' @name filter_
+#' @rdname reexports
+#' @export
+dplyr::filter_
 
 # waiting on https://github.com/tidyverse/tidyr/pull/229
 #

--- a/R/imports.R
+++ b/R/imports.R
@@ -24,23 +24,11 @@ NULL
 #' @export
 dplyr::mutate
 
-#' @importFrom dplyr mutate_
-#' @name mutate_
-#' @rdname reexports
-#' @export
-dplyr::mutate_
-
 #' @importFrom dplyr transmute
 #' @name transmute
 #' @rdname reexports
 #' @export
 dplyr::transmute
-
-#' @importFrom dplyr transmute_
-#' @name transmute_
-#' @rdname reexports
-#' @export
-dplyr::transmute_
 
 #' @importFrom dplyr select
 #' @name select
@@ -48,35 +36,17 @@ dplyr::transmute_
 #' @export
 dplyr::select
 
-#' @importFrom dplyr select_
-#' @name select_
-#' @rdname reexports
-#' @export
-dplyr::select_
-
 #' @importFrom dplyr rename
 #' @name rename
 #' @rdname reexports
 #' @export
 dplyr::rename
 
-#' @importFrom dplyr rename_
-#' @name rename_
-#' @rdname reexports
-#' @export
-dplyr::rename_
-
 #' @importFrom dplyr group_by 
 #' @name group_by
 #' @rdname reexports
 #' @export
 dplyr::group_by
-
-#' @importFrom dplyr group_by_
-#' @name group_by_
-#' @rdname reexports
-#' @export
-dplyr::group_by_
 
 #' @importFrom dplyr groups
 #' @name groups
@@ -96,47 +66,22 @@ dplyr::ungroup
 #' @export
 dplyr::summarise
 
-#' @importFrom dplyr summarise_
-#' @name summarise_
-#' @rdname reexports
-#' @export
-dplyr::summarise_
-
 #' @importFrom dplyr do
 #' @name do
 #' @rdname reexports
 #' @export
 dplyr::do
 
-#' @importFrom dplyr do_
-#' @name do_
-#' @rdname reexports
-#' @export
-dplyr::do_
-
 #' @importFrom dplyr arrange
 #' @name arrange
 #' @rdname reexports
 #' @export
 dplyr::arrange
-
-#' @importFrom dplyr arrange_
-#' @name arrange_
-#' @rdname reexports
-#' @export
-dplyr::arrange_
-
 #' @importFrom dplyr distinct
 #' @name distinct
 #' @rdname reexports
 #' @export
 dplyr::distinct
-
-#' @importFrom dplyr distinct_
-#' @name distinct_
-#' @rdname reexports
-#' @export
-dplyr::distinct_
 
 #' @importFrom dplyr slice
 #' @name slice
@@ -144,23 +89,11 @@ dplyr::distinct_
 #' @export
 dplyr::slice
 
-#' @importFrom dplyr slice_
-#' @name slice_
-#' @rdname reexports
-#' @export
-dplyr::slice_
-
 #' @importFrom dplyr filter
 #' @name filter
 #' @rdname reexports
 #' @export
 dplyr::filter
-
-#' @importFrom dplyr filter_
-#' @name filter_
-#' @rdname reexports
-#' @export
-dplyr::filter_
 
 # waiting on https://github.com/tidyverse/tidyr/pull/229
 #

--- a/R/plotly_build.R
+++ b/R/plotly_build.R
@@ -561,7 +561,7 @@ train_data <- function(data, trace) {
     idx2 <- seq.int(2, NROW(dat), by = 2)
     dat[idx2, "x"] <- data[["xend"]]
     dat[idx2, "y"] <- data[["yend"]]
-    data <- dplyr::group_by(dat, !!rlang::sym(".plotlyGroupIndex"), .add = TRUE)
+    data <- group_by_add(dat, !!rlang::sym(".plotlyGroupIndex"), add = TRUE)
   }
   
   # TODO: a lot more geoms!!!

--- a/R/plotly_build.R
+++ b/R/plotly_build.R
@@ -561,7 +561,7 @@ train_data <- function(data, trace) {
     idx2 <- seq.int(2, NROW(dat), by = 2)
     dat[idx2, "x"] <- data[["xend"]]
     dat[idx2, "y"] <- data[["yend"]]
-    data <- dplyr::group_by(dat, rlang::sym(".plotlyGroupIndex"), .add = TRUE)
+    data <- dplyr::group_by(dat, !!rlang::sym(".plotlyGroupIndex"), .add = TRUE)
   }
   
   # TODO: a lot more geoms!!!

--- a/R/plotly_build.R
+++ b/R/plotly_build.R
@@ -561,7 +561,7 @@ train_data <- function(data, trace) {
     idx2 <- seq.int(2, NROW(dat), by = 2)
     dat[idx2, "x"] <- data[["xend"]]
     dat[idx2, "y"] <- data[["yend"]]
-    data <- dplyr::group_by_(dat, ".plotlyGroupIndex", add = TRUE)
+    data <- dplyr::group_by(dat, rlang::sym(".plotlyGroupIndex"), .add = TRUE)
   }
   
   # TODO: a lot more geoms!!!

--- a/R/plotly_build.R
+++ b/R/plotly_build.R
@@ -561,7 +561,7 @@ train_data <- function(data, trace) {
     idx2 <- seq.int(2, NROW(dat), by = 2)
     dat[idx2, "x"] <- data[["xend"]]
     dat[idx2, "y"] <- data[["yend"]]
-    data <- group_by_add(dat, !!rlang::sym(".plotlyGroupIndex"), add = TRUE)
+    data <- group_by_add(dat, !!rlang::sym(".plotlyGroupIndex"))
   }
   
   # TODO: a lot more geoms!!!

--- a/R/plotly_data.R
+++ b/R/plotly_data.R
@@ -121,11 +121,11 @@ ungroup.plotly <- function(x, ...) {
 #' @export
 group_by_.plotly <- function(.data, ..., .dots, add = FALSE) {
   d <- plotly_data(.data)
-  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
-  d2 <- dplyr::group_by(d, !!!additional_args, .add = add)
+  additional_args <- dots_as_quosures(lazyeval::all_dots(.dots, ...))
+  d2 <- group_by_add(d, !!!additional_args, add = add)
   # add crosstalk key as a group (to enable examples like demos/highlight-pipeline.R)
   if (crosstalk_key() %in% names(d)) {
-    d2 <- dplyr::group_by(d2, !!crosstalk_key(), .add = TRUE)
+    d2 <- group_by_add(d2, !!rlang::sym(crosstalk_key()), add = TRUE)
   }
   add_data(.data, d2)
 }
@@ -134,7 +134,7 @@ group_by_.plotly <- function(.data, ..., .dots, add = FALSE) {
 #' @export
 summarise_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  additional_args <- dots_as_quosures(lazyeval::all_dots(.dots, ...))
   d <- dplyr::summarise(d, !!!additional_args)
   add_data(.data, d)
 }
@@ -147,7 +147,7 @@ mutate_.plotly <- function(.data, ..., .dots) {
   # '.' in a pipeline should really reference the data!!
   lapply(dotz, function(x) { assign(".", d, x$env) })
   set <- attr(d, "set")
-  d <- dplyr::mutate(d, !!!as_quosures_explicit(dotz))
+  d <- dplyr::mutate(d, !!!dots_as_quosures(dotz))
   add_data(.data, structure(d, set = set))
 }
 
@@ -159,7 +159,7 @@ do_.plotly <- function(.data, ..., .dots) {
   # '.' in a pipeline should really reference the data!!
   lapply(dotz, function(x) { assign(".", d, x$env) })
   set <- attr(d, "set")
-  d <- dplyr::do(d, !!!as_quosures_explicit(dotz))
+  d <- dplyr::do(d, !!!dots_as_quosures(dotz))
   add_data(.data, structure(d, set = set))
 }
 
@@ -167,7 +167,7 @@ do_.plotly <- function(.data, ..., .dots) {
 #' @export
 arrange_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  additional_args <- dots_as_quosures(lazyeval::all_dots(.dots, ...))
   d <- dplyr::arrange(d, !!!additional_args)
   add_data(.data, d)
 }
@@ -176,7 +176,7 @@ arrange_.plotly <- function(.data, ..., .dots) {
 #' @export
 select_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  additional_args <- dots_as_quosures(lazyeval::all_dots(.dots, ...))
   d <- dplyr::select(d, !!!additional_args)
   add_data(.data, d)
 }
@@ -185,7 +185,7 @@ select_.plotly <- function(.data, ..., .dots) {
 #' @export
 filter_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  additional_args <- dots_as_quosures(lazyeval::all_dots(.dots, ...))
   d <- dplyr::filter(d, !!!additional_args)
   add_data(.data, d)
 }
@@ -194,7 +194,7 @@ filter_.plotly <- function(.data, ..., .dots) {
 #' @export
 distinct_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  additional_args <- dots_as_quosures(lazyeval::all_dots(.dots, ...))
   d <- dplyr::distinct(d, .dots = !!!additional_args)
   add_data(.data, d)
 }
@@ -203,7 +203,7 @@ distinct_.plotly <- function(.data, ..., .dots) {
 #' @export
 slice_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  additional_args <- dots_as_quosures(lazyeval::all_dots(.dots, ...))
   d <- dplyr::slice(d, !!!additional_args)
   add_data(.data, d)
 }
@@ -212,7 +212,7 @@ slice_.plotly <- function(.data, ..., .dots) {
 #' @export
 rename_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  additional_args <- dots_as_quosures(lazyeval::all_dots(.dots, ...))
   d <- dplyr::rename(d, !!!additional_args)
   add_data(.data, d)
 }
@@ -221,7 +221,7 @@ rename_.plotly <- function(.data, ..., .dots) {
 #' @export
 transmute_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  additional_args <- dots_as_quosures(lazyeval::all_dots(.dots, ...))
   d <- dplyr::transmute(d, !!!additional_arg)
   add_data(.data, d)
 }

--- a/R/plotly_data.R
+++ b/R/plotly_data.R
@@ -125,7 +125,7 @@ group_by_.plotly <- function(.data, ..., .dots, add = FALSE) {
   d2 <- dplyr::group_by(d, !!!additional_args, .add = add)
   # add crosstalk key as a group (to enable examples like demos/highlight-pipeline.R)
   if (crosstalk_key() %in% names(d)) {
-    d2 <- dplyr::group_by(d2, !!crosstalk_key(), add = TRUE)
+    d2 <- dplyr::group_by(d2, !!crosstalk_key(), .add = TRUE)
   }
   add_data(.data, d2)
 }

--- a/R/plotly_data.R
+++ b/R/plotly_data.R
@@ -121,10 +121,11 @@ ungroup.plotly <- function(x, ...) {
 #' @export
 group_by_.plotly <- function(.data, ..., .dots, add = FALSE) {
   d <- plotly_data(.data)
-  d2 <- dplyr::group_by_(d, .dots = lazyeval::all_dots(.dots, ...), add = add)
+  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  d2 <- dplyr::group_by(d, !!!additional_args, .add = add)
   # add crosstalk key as a group (to enable examples like demos/highlight-pipeline.R)
   if (crosstalk_key() %in% names(d)) {
-    d2 <- dplyr::group_by_(d2, crosstalk_key(), add = TRUE)
+    d2 <- dplyr::group_by(d2, !!crosstalk_key(), add = TRUE)
   }
   add_data(.data, d2)
 }
@@ -133,7 +134,8 @@ group_by_.plotly <- function(.data, ..., .dots, add = FALSE) {
 #' @export
 summarise_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  d <- dplyr::summarise_(d, .dots = lazyeval::all_dots(.dots, ...))
+  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  d <- dplyr::summarise(d, !!!additional_args)
   add_data(.data, d)
 }
 
@@ -145,7 +147,7 @@ mutate_.plotly <- function(.data, ..., .dots) {
   # '.' in a pipeline should really reference the data!!
   lapply(dotz, function(x) { assign(".", d, x$env) })
   set <- attr(d, "set")
-  d <- dplyr::mutate_(d, .dots = dotz)
+  d <- dplyr::mutate(d, !!!as_quosures_explicit(dotz))
   add_data(.data, structure(d, set = set))
 }
 
@@ -157,7 +159,7 @@ do_.plotly <- function(.data, ..., .dots) {
   # '.' in a pipeline should really reference the data!!
   lapply(dotz, function(x) { assign(".", d, x$env) })
   set <- attr(d, "set")
-  d <- dplyr::do_(d, .dots = dotz)
+  d <- dplyr::do(d, !!!as_quosures_explicit(dotz))
   add_data(.data, structure(d, set = set))
 }
 
@@ -165,7 +167,8 @@ do_.plotly <- function(.data, ..., .dots) {
 #' @export
 arrange_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  d <- dplyr::arrange_(d, .dots = lazyeval::all_dots(.dots, ...))
+  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  d <- dplyr::arrange(d, !!!additional_args)
   add_data(.data, d)
 }
 
@@ -173,7 +176,8 @@ arrange_.plotly <- function(.data, ..., .dots) {
 #' @export
 select_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  d <- dplyr::select_(d, .dots = lazyeval::all_dots(.dots, ...))
+  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  d <- dplyr::select(d, !!!additional_args)
   add_data(.data, d)
 }
 
@@ -181,7 +185,8 @@ select_.plotly <- function(.data, ..., .dots) {
 #' @export
 filter_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  d <- dplyr::filter_(d, .dots = lazyeval::all_dots(.dots, ...))
+  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  d <- dplyr::filter(d, !!!additional_args)
   add_data(.data, d)
 }
 
@@ -189,7 +194,8 @@ filter_.plotly <- function(.data, ..., .dots) {
 #' @export
 distinct_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  d <- dplyr::distinct_(d, .dots = lazyeval::all_dots(.dots, ...))
+  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  d <- dplyr::distinct(d, .dots = !!!additional_args)
   add_data(.data, d)
 }
 
@@ -197,7 +203,8 @@ distinct_.plotly <- function(.data, ..., .dots) {
 #' @export
 slice_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  d <- dplyr::slice_(d, .dots = lazyeval::all_dots(.dots, ...))
+  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  d <- dplyr::slice(d, !!!additional_args)
   add_data(.data, d)
 }
 
@@ -205,7 +212,8 @@ slice_.plotly <- function(.data, ..., .dots) {
 #' @export
 rename_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  d <- dplyr::rename_(d, .dots = lazyeval::all_dots(.dots, ...))
+  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  d <- dplyr::rename(d, !!!additional_args)
   add_data(.data, d)
 }
 
@@ -213,7 +221,8 @@ rename_.plotly <- function(.data, ..., .dots) {
 #' @export
 transmute_.plotly <- function(.data, ..., .dots) {
   d <- plotly_data(.data)
-  d <- dplyr::transmute_(d, .dots = lazyeval::all_dots(.dots, ...))
+  additional_args <- as_quosures_explicit(lazyeval::all_dots(.dots, ...))
+  d <- dplyr::transmute(d, !!!additional_arg)
   add_data(.data, d)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1156,9 +1156,19 @@ longest_element <- function(x) {
 }
 
 # Apply rlang::as_quosure across a list or vector, but explicitly pass env
-# and expr to as_quosure, due to a bug in as_quosures when dealing with 
-# lazy objects
-as_quosures_explicit <- function(vec) {
-  lapply(vec, 
-         FUN = function(x) rlang::as_quosure(x$expr, x$env))
+# and expr to as_quosure
+dots_as_quosures <- function(x) {
+  if (!inherits(x, "lazy_dots")) {
+    stop("Expected lazy dots")
+  }
+  lapply(x, function(x) rlang::as_quosure(x$expr, x$env))
+}
+
+# A dplyr::group_by wrapper for the add argument
+group_by_add <- function(..., add = TRUE) {
+  if (packageVersion('dplyr') >= '1.0') {
+    dplyr::group_by(...,  .add = add)
+  } else {
+    dplyr::group_by(...,  add = add)
+  } 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1161,7 +1161,7 @@ dots_as_quosures <- function(x) {
   if (!inherits(x, "lazy_dots")) {
     stop("Expected lazy dots")
   }
-  lapply(x, function(x) rlang::as_quosure(x$expr, x$env))
+  lapply(x, function(x) rlang::new_quosure(x$expr, x$env))
 }
 
 # A dplyr::group_by wrapper for the add argument

--- a/R/utils.R
+++ b/R/utils.R
@@ -139,7 +139,7 @@ crosstalk_key <- function() ".crossTalkKey"
 # arrange data if the vars exist, don't throw error if they don't
 arrange_safe <- function(data, vars) {
   vars <- vars[vars %in% names(data)]
-  if (length(vars)) dplyr::arrange_(data, .dots = vars) else data
+  if (length(vars)) dplyr::arrange(data, !!!lapply(vars, rlang::sym)) else data
 }
 
 is_mapbox <- function(p) {
@@ -1153,4 +1153,12 @@ longest_element <- function(x) {
     x[which.max(robust_nchar(x))]
   else
     ""
+}
+
+# Apply rlang::as_quosure across a list or vector, but explicitly pass env
+# and expr to as_quosure, due to a bug in as_quosures when dealing with 
+# lazy objects
+as_quosures_explicit <- function(vec) {
+  lapply(vec, 
+         FUN = function(x) rlang::as_quosure(x$expr, x$env))
 }


### PR DESCRIPTION
Replaced all instances of depreciated standard evaluation dplyr verbs with their NSE equivalents.

Fixes associated depreciation warnings, so closes #1783. For example,

Before:

```R
> p <- ggplot(txhousing, aes(x = date, y = median, group = city)) +
+   geom_line(alpha = 0.3)
> ggplotly(p) %>% filter(city == "Houston")
Warning message:
`filter_()` is deprecated as of dplyr 0.7.0.
Please use `filter()` instead.
See vignette('programming') for more help
```

After:

```R
> p <- ggplot(txhousing, aes(x = date, y = median, group = city)) +
+   geom_line(alpha = 0.3)
> ggplotly(p) %>% filter(city == "Houston")
```

This PR introduces a util function called `as_quosures_explicit`. If/when [issue 1009 in r-lang](https://github.com/r-lib/rlang/issues/1009) is resolved, just replace all instances of `as_quosures_explicit` with `rlang::as_quosures`.  