### PR TITLE
Add reportTheme argument to plotlyOutput() for reporting CSS styles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,4 +78,6 @@ LazyData: true
 RoxygenNote: 7.1.0
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-Remotes: rstudio/thematic
+Remotes: 
+  rstudio/thematic,
+  ramnathv/htmlwidgets

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 ## NEW FEATURES
 
-* `ggplotly()` now works well with the [**thematic** package](https://rstudio.github.io/thematic). That is, it can now correctly translate **ggplot2** styling that derives from **thematic** (#1801).
+* `ggplotly()` now works well with the [**thematic** package](https://rstudio.github.io/thematic). That is, it can now correctly translate **ggplot2** styling that derives from **thematic**. Note that, in order to use **thematic**'s auto theming in Shiny with `ggplotly()`, you need **shiny** v1.5.0 (or higher) and **htmlwidgets** v1.5.1.9001 (or higher). Relatedly, if these versions are available, one may now also call `getCurrentOutputInfo()` inside `renderPlotly()` to get CSS styles of the output container (#1801 and #1802).
 
 ## IMPROVEMENTS
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -11,6 +11,8 @@
 #'   height is computed with HTML/CSS.
 #' @param inline use an inline (`span()`) or block container 
 #' (`div()`) for the output
+#' @param reportTheme whether or not to report CSS styles (if a sufficient
+#' version of shiny and htmlwidgets is available).
 #' @param expr An expression that generates a plotly
 #' @param env The environment in which to evaluate `expr`.
 #' @param quoted Is `expr` a quoted expression (with `quote()`)? This 
@@ -22,8 +24,8 @@
 #'
 #' @export
 plotlyOutput <- function(outputId, width = "100%", height = "400px", 
-                         inline = FALSE) {
-  htmlwidgets::shinyWidgetOutput(
+                         inline = FALSE, reportTheme = TRUE) {
+  args <- list(
     outputId = outputId, 
     name = "plotly", 
     width = width, 
@@ -32,6 +34,10 @@ plotlyOutput <- function(outputId, width = "100%", height = "400px",
     package = "plotly",
     reportSize = TRUE
   )
+  if (is_available("shiny", "1.4.0.9003") && is_available("htmlwidgets", "1.5.1.9001")) {
+    args$reportTheme <- reportTheme
+  }
+  do.call(htmlwidgets::shinyWidgetOutput, args)
 }
 
 #' @rdname plotly-shiny

--- a/R/utils.R
+++ b/R/utils.R
@@ -1137,6 +1137,15 @@ try_library <- function(pkg, fun = NULL) {
        "Please install and try again.", call. = FALSE)
 }
 
+# a la shiny:::is_available
+is_available <- function(package, version = NULL) {
+  installed <- nzchar(system.file(package = package))
+  if (is.null(version)) {
+    return(installed)
+  }
+  installed && isTRUE(utils::packageVersion(package) >= version)
+}
+
 # similar logic to rstudioapi::isAvailable()
 is_rstudio <- function() {
   identical(.Platform$GUI, "RStudio")

--- a/man/plotly-shiny.Rd
+++ b/man/plotly-shiny.Rd
@@ -6,7 +6,13 @@
 \alias{renderPlotly}
 \title{Shiny bindings for plotly}
 \usage{
-plotlyOutput(outputId, width = "100\%", height = "400px", inline = FALSE)
+plotlyOutput(
+  outputId,
+  width = "100\%",
+  height = "400px",
+  inline = FALSE,
+  reportTheme = TRUE
+)
 
 renderPlotly(expr, env = parent.frame(), quoted = FALSE)
 }
@@ -21,6 +27,9 @@ height is computed with HTML/CSS.}
 
 \item{inline}{use an inline (\code{span()}) or block container
 (\code{div()}) for the output}
+
+\item{reportTheme}{whether or not to report CSS styles (if a sufficient
+version of shiny and htmlwidgets is available).}
 
 \item{expr}{An expression that generates a plotly}
 

--- a/man/plotly_IMAGE.Rd
+++ b/man/plotly_IMAGE.Rd
@@ -27,7 +27,7 @@ plotly_IMAGE(
 
 \item{out_file}{A filename for writing the image to a file.}
 
-\item{...}{arguments passed onto \code{httr::POST}}
+\item{...}{arguments passed onto \code{httr::RETRY}}
 }
 \description{
 The images endpoint turns a plot (which may be given in multiple forms)


### PR DESCRIPTION
Adds the ability to access the new CSS styles reported in `getCurrentOutputInfo()` inside of a `renderPlotly()` context. For example:

```r
library(shiny)
library(plotly)

ui <- fluidPage(
  tags$style(HTML("body {background-color: black; color: white}")),
  tags$style(HTML("body a {color: orange}")),
  plotlyOutput("p")
)

server <- function(input, output, session) {
  
  output$p <- renderPlotly({
    info <- getCurrentOutputInfo()
    plot_ly(x = 0:10, y = 0:10, color = I(info$accent())) %>%
      layout(
        font = list(color = info$fg()),
        paper_bgcolor = info$bg(),
        plot_bgcolor = info$bg(),
        xaxis = list(
          gridcolor = info$fg(),
          zerolinecolor = info$fg()
        ),
        yaxis = list(
          gridcolor = info$fg(),
          zerolinecolor = info$fg()
        )
      )
  })
  
}

shinyApp(ui, server)
```


This'll provide the foundation **thematic** and `ggplotly()` need to make this possible

```r
library(shiny)
library(plotly)
library(thematic)

thematic_shiny()

ui <- fluidPage(
  titlePanel("Hello auto theming with ggplotly()"),
  tags$head(
    tags$style(HTML("body{background-color:#444444; color:#e4e4e4}")),
    tags$style(HTML("a{color:#e39777}"))
  ),
  plotlyOutput("p")
)

server <- function(input, output, session) {
  output$p <- renderPlotly({
    p <- ggplot(faithfuld, aes(waiting, eruptions, z = density)) + 
      geom_raster(aes(fill = density)) + 
      geom_contour()
    ggplotly(p)
  })
}

shinyApp(ui, server)
```

<img width="894" alt="Screen Shot 2020-06-26 at 11 15 28 AM" src="https://user-images.githubusercontent.com/1365941/85878519-71c9fc80-b79e-11ea-9c01-c1e68945229f.png">

