### PR TITLE
Add support for shiny::bindCache

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     viridisLite,
     base64enc,
     htmltools (>= 0.3.6),
-    htmlwidgets (>= 1.3),
+    htmlwidgets (>= 1.5.2.9001),
     tidyr,
     hexbin,
     RColorBrewer,

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -55,9 +55,10 @@ renderPlotly <- function(expr, env = parent.frame(), quoted = FALSE) {
   # objects to renderPlotly() (e.g., ggplot2, promises). It also is used 
   # to inform event_data about what events have been registered
   shiny::installExprFunction(expr, "func", env, quoted)
-  expr <- quote(getFromNamespace("prepareWidget", "plotly")(func()))
-  local_env <- environment()
-  renderFunc <- shinyRenderWidget(expr, plotlyOutput, local_env, quoted)
+  expr2 <- quote(getFromNamespace("prepareWidget", "plotly")(func()))
+  renderFunc <- shinyRenderWidget(expr2, plotlyOutput, environment(), quoted,
+    cacheHint = list(label = "renderPlotly", userExpr = expr)
+  )
   # remove 'internal' plotly attributes that are known to cause false
   # positive test results in shinytest (snapshotPreprocessOutput was added 
   # in shiny 1.0.3.9002, but we require >= 1.1)


### PR DESCRIPTION
To be merged after https://github.com/ramnathv/htmlwidgets/pull/391.

This makes `renderPlotly` work with `shiny::bindCache` in the dev version of shiny. For example:

```R
library(shiny)
library(plotly)

ui <- fluidPage(
  selectizeInput(
    inputId = "cities", 
    label = "Select a city", 
    choices = unique(txhousing$city), 
    selected = "Abilene",
    multiple = TRUE
  ),
  plotlyOutput(outputId = "p")
)

server <- function(input, output, ...) {
  output$p <- renderPlotly({
    message("Computing p: ", paste(input$cities, collapse = ", "))
    Sys.sleep(2)
    plot_ly(txhousing, x = ~date, y = ~median) %>%
      filter(city %in% input$cities) %>%
      group_by(city) %>%
      add_lines()
  }) %>% 
    bindCache(input$cities)

}

shinyApp(ui, server)
```