### PR TITLE
Fixes for ggplot2 3.3.4 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Duplicate `highlight(selectize=T)` dropdowns are no longer rendered in Shiny (#1936).
 * `group_by.plotly()` now properly retains crosstalk information across `{dplyr}` versions (#1920).
+* Adds fixes in `ggplotly()` for the upcoming `{ggplot2}` >3.3.3 release (#1952).
 * Fixes some issues with `name` and `frames` when both attributes are specified. (#1903 and #1618).
 
 # 4.9.3

--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -1099,7 +1099,7 @@ gg2list <- function(p, width = NULL, height = NULL,
   # start build a plotly object with meta information about the ggplot
   # first, translate layer mappings -> plotly attrs
   mappingFormulas <- lapply(layers, function(x) {
-    mappings <- c(x$mapping, if (isTRUE(x$inherit.aes)) plot$mapping)
+    mappings <- getAesMap(plot, x)
     if (originalData) {
       lapply(mappings, lazyeval::f_new)
     } else {
@@ -1425,5 +1425,14 @@ gdef2trace <- function(gdef, theme, gglayout) {
     # if plotly.js gets better support for multiple legends,
     # that conversion should go here
     NULL
+  }
+}
+
+
+getAesMap <- function(plot, layer) {
+  if (isTRUE(layer$inherit.aes)) {
+    modify_list(plot$mapping, layer$mapping)
+  } else {
+    layer$mapping
   }
 }

--- a/R/layers2layout.R
+++ b/R/layers2layout.R
@@ -3,7 +3,7 @@ layers2layout <- function(gglayout, layers, layout) {
   geoms <- sapply(layers, function(x) class(x[["geom"]])[1])
   RasterGeom <- which(geoms %in% "GeomRasterAnn")
   for (i in RasterGeom) {
-    params <- layers[[i]]$geom_params
+    params <- layers[[i]]$computed_geom_params %||% layers[[i]]$geom_params
     for (j in seq_len(nrow(layout))) {
       lay <- layout[j, ]
       

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -12,8 +12,7 @@ layers2traces <- function(data, prestats_data, layout, p) {
       position = ggtype(y, "position")
     )
     
-    # add on plot-level mappings, if they're inherited
-    map <- c(y$mapping, if (isTRUE(y$inherit.aes)) p$mapping)
+    map <- getAesMap(p, y)
     
     # consider "calculated" aesthetics (e.g., density, count, etc)
     calc_aes <- y$stat$default_aes[ggfun("is_calculated_aes")(y$stat$default_aes)]

--- a/R/layers2traces.R
+++ b/R/layers2traces.R
@@ -6,7 +6,9 @@ layers2traces <- function(data, prestats_data, layout, p) {
   # Extract parameters (and "hovertext aesthetics") in each layer
   params <- Map(function(x, y) {
     param <- c(
-      y[["geom_params"]], y[["stat_params"]], y[["aes_params"]], 
+      y[["computed_geom_params"]] %||% y[["geom_params"]], 
+      y[["computed_stat_params"]] %||% y[["stat_params"]], 
+      y[["aes_params"]], 
       position = ggtype(y, "position")
     )
     


### PR DESCRIPTION
Closes #1951 and another issue with `aes()` mappings getting duplicated in tooltips (surfaced via unit tests) 