### PR TITLE
Add crosstalk mapping to computed_mapping (not mapping) when present

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: plotly
 Title: Create Interactive Web Graphics via 'plotly.js'
-Version: 4.9.4
+Version: 4.9.4.9000
 Authors@R: c(person("Carson", "Sievert", role = c("aut", "cre"),
     email = "cpsievert1@gmail.com", comment = c(ORCID = "0000-0002-4958-2844")),
     person("Chris", "Parmer", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,16 @@
+# 4.9.4.9000
+
+## BUG FIXES
+
+* Fixes a bug in `ggplotly()` with `{crosstalk}` and `{ggplot2}` v3.3.4  (#1952).
+
 # 4.9.4
 
 ## BUG FIXES
 
 * Duplicate `highlight(selectize=T)` dropdowns are no longer rendered in Shiny (#1936).
 * `group_by.plotly()` now properly retains crosstalk information across `{dplyr}` versions (#1920).
-* Adds fixes in `ggplotly()` for the upcoming `{ggplot2}` >3.3.3 release (#1952).
+* Adds fixes in `ggplotly()` for the upcoming `{ggplot2}` v3.3.4 release (#1952).
 * Fixes some issues with `name` and `frames` when both attributes are specified. (#1903 and #1618).
 
 # 4.9.3

--- a/R/ggplotly.R
+++ b/R/ggplotly.R
@@ -264,7 +264,12 @@ gg2list <- function(p, width = NULL, height = NULL,
     layers <- Map(function(x, y) {
       if (crosstalk_key() %in% names(y) && !"key" %in% names(x[["mapping"]]) && 
           inherits(x[["stat"]], "StatIdentity")) {
-        x[["mapping"]] <- c(x[["mapping"]], key = as.name(crosstalk_key()))
+        # ggplot2 v3.3.4 started using the computed_mapping (instead of mapping)
+        # field to inform the compute_aesthetics() method, so in order to add
+        # the crosstalk key, we need to add to that field (when present)
+        # https://github.com/tidyverse/ggplot2/pull/4475
+        nm <- if ("computed_mapping" %in% names(x)) "computed_mapping" else "mapping"
+        x[[nm]] <- c(x[[nm]], key = as.name(crosstalk_key()))
       }
       x
     }, layers, layer_data)


### PR DESCRIPTION
Follow up to #1952. I missed the changes made in https://github.com/tidyverse/ggplot2/pull/4475, which introduces the following failures (this change fixes them):

```
  ══ Failed tests ════════════════════════════════════════════════════════════════
  ── Failure (test-animate-highlight.R:119:7): When key is equivalent to group, produce simple keys ──
  tr$key == tr$name is not TRUE
  
  `actual`:
  `expected`: TRUE
  ── Failure (test-animate-highlight.R:120:7): When key is equivalent to group, produce simple keys ──
  tr$`_isSimpleKey` is not TRUE
  
  `actual` is NULL
  `expected` is a logical vector (TRUE)
  ── Failure (test-animate-highlight.R:119:7): When key is equivalent to group, produce simple keys ──
  tr$key == tr$name is not TRUE
  
  `actual`:
  `expected`: TRUE
  ── Failure (test-animate-highlight.R:120:7): When key is equivalent to group, produce simple keys ──
  tr$`_isSimpleKey` is not TRUE
  
  `actual` is NULL
  `expected` is a logical vector (TRUE)
  
  [ FAIL 4 | WARN 36 | SKIP 56 | PASS 1404 ]
```