### PR TITLE
Use Plotly.react() to redraw in Shiny if layout.transition is populated

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,13 @@
 # 4.9.4.9000
 
-## Changes to plotly.js
+## Breaking changes in JavaScript API
 
 * This version of the R package upgrades the version of the underlying plotly.js library from v1.57.1 to v2.2.1. This includes many breaking changes, bug fixes, and improvements to the underlying JavaScript library. The [plotly.js release page](https://github.com/plotly/plotly.js/releases) has the full list of changes.
 
-## Breaking changes
+## Breaking changes in R API
 
 * `ggplotly()` now uses the `layout.legend.title` (instead of `layout.annotations`) plotly.js API to convert guides for discrete scales. (#1961)
+* `renderPlotly()` now uses `Plotly.react()` (instead of `Plotly.newPlot()`) to redraw when `layout(transition = )` is specified. This makes it possible/easier to implement a smooth transitions when `renderPlotly()` gets re-executed. (#2001)
 
 ## New Features
 

--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -162,6 +162,10 @@ HTMLWidgets.widget({
       var plot = Plotly.newPlot(graphDiv, x);
       instance.plotly = true;
       
+    } else if (x.layout.transition) {
+      
+      var plot = Plotly.react(graphDiv, x);
+    
     } else {
       
       // this is essentially equivalent to Plotly.newPlot(), but avoids creating 


### PR DESCRIPTION
This change makes it easier to implement smooth transitions when `renderPlotly()` is performing a redraw (by specifying `layout(transition = ...)`), which from my limited experimentation works reasonably well with `scatter` traces, especially if you have `xaxis.range`/`yaxis.range` fixed "globally". Here's a basic example:

```r
library(shiny)
library(plotly)

ui <- fluidPage(
  plotlyOutput("p")
)

server <- function(input, output, session) {
  output$p <- renderPlotly({
    invalidateLater(1000)
    plot_ly() %>%
      add_markers(x = rnorm(100), y = rnorm(100), alpha = 0.2) %>%
      layout(
        xaxis = list(range = c(-3, 3)),
        yaxis = list(range = c(-3, 3)),
        transition = list(
          duration = 1000, 
          easing = "linear"
        )
      )
  })
}

shinyApp(ui, server)
```

Unfortunately `Plotly.react()` doesn't seem to support smooth transitions of non-scatter traces very well, but one can leverage workarounds such as https://plotly-r.com/animating-views.html#animation-support to implement things like animated "bars" 